### PR TITLE
#6  DRUP-810: Add SmartDocs to API Catalog module

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,7 @@ Once added, the API name and description for each API Doc will be displayed in t
 "View published API docs" permissions if you want to allow registered or anonymous users 
 to be able to view published API documentation.
 
-The OpenAPI spec by default is shown on the API Doc detail page by default.
-To render the OpenAPI spec using Swagger UI:
-
-1. Install an enable the [Swagger UI Field Formatter](https://www.drupal.org/project/swagger_ui_formatter) module.
-2. Install the Swagger UI JS library as documented [on the module page](https://www.drupal.org/project/swagger_ui_formatter).
-3. Go to __Configuration > API catalog > Manage display__ in the admin menu.
-4. Change "OpenAPI specification" field format to use the Swagger UI field formatter.
+The OpenAPI spec by default is rendered using Apigee SmartDocs.
 
 The API Doc is an entity, you can configure it at __Configuration > API catalog__ in the admin
 menu.
@@ -28,7 +22,6 @@ under Structure > Views in the admin menu.
 
 ## Planned Features
 
-- Create additional field formatters to use for rendering OpenAPI specs
 - Integration with Apigee API Products
 - Allow OpenAPI specs to be associated to a source location such as Apigee Edge or a URL
 - Add visual notifications when source URL specs have changed on the API Doc admin screen
@@ -36,7 +29,9 @@ under Structure > Views in the admin menu.
 
 ### Known issues
 
-- none
+- The Apigee SmartDocs formatter can only render one OpenAPI spec per page and the URL pattern
+  must match `/api/{entityId}`.  This means that the formatter will probably not work correctly if 
+  you modify the default API Docs view or try to use this file Formatter on nodes or other entities.
 
 ## Installing
 

--- a/apigee_api_catalog.libraries.yml
+++ b/apigee_api_catalog.libraries.yml
@@ -1,19 +1,19 @@
 # SmartDocs Drupal Angular application.
 apigee_api_catalog.smartdocs:
-  version: 1.0
+  version: 1.0.0
   license:
     name: Proprietary Google Code
-    gpl-compatible: true
+    gpl-compatible: false
   css:
     component:
       https://fonts.googleapis.com/icon?family=Material+Icons: { type: external }
   js:
-    js/smartdocs-drupal/es2015-polyfills.js: {}
-    js/smartdocs-drupal/main.js: {}
-    js/smartdocs-drupal/polyfills.js: {}
-    js/smartdocs-drupal/runtime.js: {}
-    js/smartdocs-drupal/styles.js: {}
-    js/smartdocs-drupal/vendor.js: {}
+    https://www.gstatic.com/smartdocs/1.0.0/es2015-polyfills.js: { type: external }
+    https://www.gstatic.com/smartdocs/1.0.0/main.js: { type: external }
+    https://www.gstatic.com/smartdocs/1.0.0/polyfills.js: { type: external }
+    https://www.gstatic.com/smartdocs/1.0.0/runtime.js: { type: external }
+    https://www.gstatic.com/smartdocs/1.0.0/styles.js: { type: external }
+    https://www.gstatic.com/smartdocs/1.0.0/vendor.js: { type: external }
 
 # Integration of SmartDocs Angular application with Drupal,
 # passes the OpenAPI spec URL to the SmartDocs ng app.

--- a/apigee_api_catalog.libraries.yml
+++ b/apigee_api_catalog.libraries.yml
@@ -13,7 +13,6 @@ apigee_api_catalog.smartdocs:
     https://www.gstatic.com/smartdocs/1.0.1/main.js: { type: external, minified: true }
     https://www.gstatic.com/smartdocs/1.0.1/polyfills.js: { type: external, minified: true }
     https://www.gstatic.com/smartdocs/1.0.1/runtime.js: { type: external, minified: true }
-    https://www.gstatic.com/smartdocs/1.0.1/styles.js: { type: external, minified: true }
     https://www.gstatic.com/smartdocs/1.0.1/vendor.js: { type: external, minified: true }
 
 # Integration of SmartDocs Angular application with Drupal,

--- a/apigee_api_catalog.libraries.yml
+++ b/apigee_api_catalog.libraries.yml
@@ -7,13 +7,14 @@ apigee_api_catalog.smartdocs:
   css:
     component:
       https://fonts.googleapis.com/icon?family=Material+Icons: { type: external }
+      https://www.gstatic.com/smartdocs/1.0.1/styles.css: { type: external }
   js:
-    https://www.gstatic.com/smartdocs/1.0.0/es2015-polyfills.js: { type: external }
-    https://www.gstatic.com/smartdocs/1.0.0/main.js: { type: external }
-    https://www.gstatic.com/smartdocs/1.0.0/polyfills.js: { type: external }
-    https://www.gstatic.com/smartdocs/1.0.0/runtime.js: { type: external }
-    https://www.gstatic.com/smartdocs/1.0.0/styles.js: { type: external }
-    https://www.gstatic.com/smartdocs/1.0.0/vendor.js: { type: external }
+    https://www.gstatic.com/smartdocs/1.0.1/es2015-polyfills.js: { type: external, minified: true }
+    https://www.gstatic.com/smartdocs/1.0.1/main.js: { type: external, minified: true }
+    https://www.gstatic.com/smartdocs/1.0.1/polyfills.js: { type: external, minified: true }
+    https://www.gstatic.com/smartdocs/1.0.1/runtime.js: { type: external, minified: true }
+    https://www.gstatic.com/smartdocs/1.0.1/styles.js: { type: external, minified: true }
+    https://www.gstatic.com/smartdocs/1.0.1/vendor.js: { type: external, minified: true }
 
 # Integration of SmartDocs Angular application with Drupal,
 # passes the OpenAPI spec URL to the SmartDocs ng app.

--- a/apigee_api_catalog.libraries.yml
+++ b/apigee_api_catalog.libraries.yml
@@ -24,3 +24,13 @@ apigee_api_catalog.smartdocs_integration:
   dependencies:
     - core/jquery
     - core/drupal
+
+# Library to parse OpenAPI YAML files to pass to SmartDocs Angular app.
+apigee_api_catalog.js_yaml:
+  version: 3.13.1
+  license:
+    name: MIT
+    url: https://github.com/nodeca/js-yaml/blob/master/LICENSE
+    gpl-compatible: true
+  js:
+    https://cdn.jsdelivr.net/npm/js-yaml@3.13.1/dist/js-yaml.min.js: { type: external, minified: true }

--- a/apigee_api_catalog.libraries.yml
+++ b/apigee_api_catalog.libraries.yml
@@ -1,0 +1,26 @@
+# SmartDocs Drupal Angular application.
+apigee_api_catalog.smartdocs:
+  version: 1.0
+  license:
+    name: Proprietary Google Code
+    gpl-compatible: true
+  css:
+    component:
+      https://fonts.googleapis.com/icon?family=Material+Icons: { type: external }
+  js:
+    js/smartdocs-drupal/es2015-polyfills.js: {}
+    js/smartdocs-drupal/main.js: {}
+    js/smartdocs-drupal/polyfills.js: {}
+    js/smartdocs-drupal/runtime.js: {}
+    js/smartdocs-drupal/styles.js: {}
+    js/smartdocs-drupal/vendor.js: {}
+
+# Integration of SmartDocs Angular application with Drupal,
+# passes the OpenAPI spec URL to the SmartDocs ng app.
+apigee_api_catalog.smartdocs_integration:
+  version: VERSION
+  js:
+    js/smartdocs_integration.js: {}
+  dependencies:
+    - core/jquery
+    - core/drupal

--- a/apigee_api_catalog.module
+++ b/apigee_api_catalog.module
@@ -40,3 +40,31 @@ function apigee_api_catalog_help($route_name, RouteMatchInterface $route_match) 
     default:
   }
 }
+
+/**
+ * Implements hook_page_attachments().
+ */
+function apigee_api_catalog_page_attachments(array &$attachments) {
+  // Add base tag for SmartDocs Angular application.
+  $xuacompatible = [
+    '#tag' => 'base',
+    '#attributes' => [
+      'href' => '/',
+    ],
+  ];
+  $attachments['#attached']['html_head'][] = [$xuacompatible, 'base-href'];
+
+  // Add script to fix issue with SmartDocs Angular app.
+  $attachments['#attached']['html_head'][] = [
+    [
+      '#type' => 'html_tag',
+      '#tag' => 'script',
+      '#value' => '(window as any).global = window; ',
+      '#attributes' => ['src' => ''],
+      '#weight' => -1,
+
+    ],
+    // Key to make it possible to recognize this HTML element when altering.
+    'apigee-smartdocs',
+  ];
+}

--- a/apigee_api_catalog.module
+++ b/apigee_api_catalog.module
@@ -41,17 +41,3 @@ function apigee_api_catalog_help($route_name, RouteMatchInterface $route_match) 
   }
 }
 
-/**
- * Implements hook_page_attachments().
- */
-function apigee_api_catalog_page_attachments(array &$attachments) {
-  // Add base tag for SmartDocs Angular application.
-  $xuacompatible = [
-    '#tag' => 'base',
-    '#attributes' => [
-      'href' => '/',
-    ],
-  ];
-  $attachments['#attached']['html_head'][] = [$xuacompatible, 'base-href'];
-
-}

--- a/apigee_api_catalog.module
+++ b/apigee_api_catalog.module
@@ -54,17 +54,4 @@ function apigee_api_catalog_page_attachments(array &$attachments) {
   ];
   $attachments['#attached']['html_head'][] = [$xuacompatible, 'base-href'];
 
-  // Add script to fix issue with SmartDocs Angular app.
-  $attachments['#attached']['html_head'][] = [
-    [
-      '#type' => 'html_tag',
-      '#tag' => 'script',
-      '#value' => '(window as any).global = window; ',
-      '#attributes' => ['src' => ''],
-      '#weight' => -1,
-
-    ],
-    // Key to make it possible to recognize this HTML element when altering.
-    'apigee-smartdocs',
-  ];
 }

--- a/js/smartdocs_integration.js
+++ b/js/smartdocs_integration.js
@@ -15,11 +15,25 @@
         if (drupalSettings.smartdocsFieldFormatter.hasOwnProperty(fieldName)) {
           const field = drupalSettings.smartdocsFieldFormatter[fieldName];
           for (let fieldDelta = 0; fieldDelta < field.openApiFiles.length; fieldDelta++) {
-             specMap[field.entityId] = field.openApiFiles[fieldDelta];
+            // Each openApiFile var has the spec url and file extension.
+            const fileUrl = field.openApiFiles[fieldDelta].fileUrl;
+            const fileExtention = field.openApiFiles[fieldDelta].fileExtension;
+            // Get the OpenAPI spec file from the server.
+            $.get(fileUrl, function(data, status) {
+              if (fileExtention === 'json') {
+                // JSON files do not need any conversion.
+                specMap[field.entityId] = data;
+              }
+              else {
+                // YAML files need to be parsed into javascript object.
+                specMap[field.entityId]  = jsyaml.load(data);
+             }
+              // Store the spec into session storage.
+              sessionStorage.setItem('specs', JSON.stringify(specMap));
+            });
           }
         }
       }
-      sessionStorage.setItem('specs', JSON.stringify(specMap));
     }
   };
 

--- a/js/smartdocs_integration.js
+++ b/js/smartdocs_integration.js
@@ -1,0 +1,23 @@
+/**
+ * @file
+ * Integration of SmartDocs file field formatter.
+ */
+
+(function ($, window, Drupal) {
+
+  Drupal.behaviors.smartdocsFieldFormatter = {
+    attach: function (context) {
+      let specMap = {};
+      for (let fieldName in drupalSettings.smartdocsFieldFormatter) {
+        if (drupalSettings.smartdocsFieldFormatter.hasOwnProperty(fieldName)) {
+          const field = drupalSettings.smartdocsFieldFormatter[fieldName];
+          for (let fieldDelta = 0; fieldDelta < field.openApiFiles.length; fieldDelta++) {
+             specMap[field.entityId] = field.openApiFiles[fieldDelta];
+          }
+        }
+      }
+      sessionStorage.setItem('specs', JSON.stringify(specMap));
+    }
+  };
+
+}(jQuery, window, Drupal));

--- a/js/smartdocs_integration.js
+++ b/js/smartdocs_integration.js
@@ -1,6 +1,9 @@
 /**
  * @file
  * Integration of SmartDocs file field formatter.
+ *
+ * Take the OpenAPI spec and put into session storage for the SmartDocs
+ * Angular app to use.
  */
 
 (function ($, window, Drupal) {

--- a/src/Entity/ApiDoc.php
+++ b/src/Entity/ApiDoc.php
@@ -190,8 +190,8 @@ class ApiDoc extends ContentEntityBase implements ApiDocInterface {
         'type' => 'file',
         'weight' => -4,
       ])->setDisplayOptions('view', [
-        'label' => 'above',
-        'type' => 'file_default',
+        'label' => 'hidden',
+        'type' => 'apigee_api_catalog_smartdocs',
         'weight' => 0,
       ])
       ->setDisplayOptions('form', [

--- a/src/Plugin/Field/FieldFormatter/SmartDocsFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/SmartDocsFormatter.php
@@ -94,19 +94,20 @@ class SmartDocsFormatter extends FileFormatterBase implements ContainerFactoryPl
   /**
    * {@inheritdoc}
    */
-  public function view(FieldItemListInterface $items, $langcode = NULL) {
-    $elements = parent::view($items, $langcode);
+  public function viewElements(FieldItemListInterface $items, $langcode) {
 
     $entity = $items->getEntity();
     $entity_type = $entity->getEntityTypeId();
 
+    // The list of OpenAPI specs to pass to SmartDocs Angular app.
     $openapi_files = [];
 
     /** @var \Drupal\file\Entity\File $file */
     foreach ($this->getEntitiesToView($items, $langcode) as $delta => $file) {
-      $openapi_file_urls[] = file_create_url($file->getFileUri());
       $file_extension = pathinfo($file->getFilename(), PATHINFO_EXTENSION);
       $file_data = file_get_contents($file->getFileUri());
+
+      // Decode the file to pass to the javascript file.
       if ($file_extension == 'json') {
         $spec = Json::decode($file_data);
 
@@ -142,25 +143,14 @@ class SmartDocsFormatter extends FileFormatterBase implements ContainerFactoryPl
     ];
 
     $elements['#attached']['drupalSettings']['smartdocsFieldFormatter'][$this->fieldDefinition->getName()] = [
-      'openApiFileUrls' => $openapi_file_urls,
       'openApiFiles' => $openapi_files,
       'entityId' => $entity->id(),
       'entityType' => $entity_type,
     ];
 
-    return $elements;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function viewElements(FieldItemListInterface $items, $langcode) {
-    $elements = [];
-
     foreach ($items as $delta => $item) {
       $elements[$delta] = [
-        // Render out tags for SmartDocs Angular app.
-        // See theme_html_tag().
+        // Create tag on page for SmartDocs Angular app.
         '#type' => 'html_tag',
         '#tag' => 'app-root',
         '#value' => $this->t('Loading...'),

--- a/src/Plugin/Field/FieldFormatter/SmartDocsFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/SmartDocsFormatter.php
@@ -94,6 +94,24 @@ class SmartDocsFormatter extends FileFormatterBase implements ContainerFactoryPl
   /**
    * {@inheritdoc}
    */
+  public function view(FieldItemListInterface $items, $langcode = NULL) {
+    $elements = parent::view($items, $langcode);
+
+    // Add base tag for SmartDocs Angular application.
+    $xuacompatible = [
+      '#tag' => 'base',
+      '#attributes' => [
+        'href' => '/',
+      ],
+    ];
+    $elements['#attached']['html_head'][] = [$xuacompatible, 'base-href'];
+    return $elements;
+
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function viewElements(FieldItemListInterface $items, $langcode) {
 
     $entity = $items->getEntity();

--- a/src/Plugin/Field/FieldFormatter/SmartDocsFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/SmartDocsFormatter.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * Copyright 2018 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_api_catalog\Plugin\Field\FieldFormatter;
+
+use Drupal\Component\Serialization\Exception\InvalidDataTypeException;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Serialization\Yaml;
+use Drupal\file\Plugin\Field\FieldFormatter\FileFormatterBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Component\Serialization\Json;
+
+/**
+ * Plugin implementation of the SmartDocs OpenAPI spec formatter.
+ *
+ * @FieldFormatter(
+ *   id = "apigee_api_catalog_smartdocs",
+ *   label = @Translation("SmartDocs"),
+ *   description = @Translation("Formats OpenAPI specs with SmartDocs"),
+ *   field_types = {
+ *     "file"
+ *   }
+ * )
+ */
+class SmartDocsFormatter extends FileFormatterBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The logger factory.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   */
+  protected $loggerFactory;
+
+  /**
+   * Constructs a EntityReferenceEntityFormatter instance.
+   *
+   * @param string $plugin_id
+   *   The plugin_id for the formatter.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
+   *   The definition of the field to which the formatter is associated.
+   * @param array $settings
+   *   The formatter settings.
+   * @param string $label
+   *   The formatter label display setting.
+   * @param string $view_mode
+   *   The view mode.
+   * @param array $third_party_settings
+   *   Any third party settings settings.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $loggerFactory
+   *   The logger factory.
+   */
+  public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, $label, $view_mode, array $third_party_settings, LoggerChannelFactoryInterface $loggerFactory) {
+    parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
+    $this->loggerFactory = $loggerFactory->get('apigee_api_catalog');;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $plugin_id,
+      $plugin_definition,
+      $configuration['field_definition'],
+      $configuration['settings'],
+      $configuration['label'],
+      $configuration['view_mode'],
+      $configuration['third_party_settings'],
+      $container->get('logger.factory')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function view(FieldItemListInterface $items, $langcode = NULL) {
+    $elements = parent::view($items, $langcode);
+
+    $entity = $items->getEntity();
+    $entity_type = $entity->getEntityTypeId();
+
+    $openapi_files = [];
+
+    /** @var \Drupal\file\Entity\File $file */
+    foreach ($this->getEntitiesToView($items, $langcode) as $delta => $file) {
+      $openapi_file_urls[] = file_create_url($file->getFileUri());
+      $extension = end(explode(".", $file->getFilename()));
+      $file_data = file_get_contents($file->getFileUri());
+      if ($extension == 'json') {
+        $spec = Json::decode($file_data);
+
+        if (!$spec) {
+          $this->loggerFactory->error('Error parsing JSON file ' . $file->getFilename());
+          $this->messenger()->addError($this->t('Error parsing JSON file %filename.', [
+            '%filename' => $file->getFilename(),
+          ]));
+          continue;
+        }
+      }
+      else {
+        try {
+          $spec = Yaml::decode($file_data);
+        }
+        catch (InvalidDataTypeException $e) {
+          $this->loggerFactory->error('Error parsing Yaml file ' . $file->getFilename() . ': ' . $e->getMessage());
+          $this->messenger()->addError($this->t('Error parsing Yaml file %filename: %error', [
+            '%filename' => $file->getFilename(),
+            '%error' => $e->getMessage(),
+          ]));
+          continue;
+        }
+      }
+      $openapi_files[] = $spec;
+    }
+
+    $elements['#attached'] = [
+      'library' => [
+        'apigee_api_catalog/apigee_api_catalog.smartdocs',
+        'apigee_api_catalog/apigee_api_catalog.smartdocs_integration',
+      ],
+    ];
+
+    $elements['#attached']['drupalSettings']['smartdocsFieldFormatter'][$this->fieldDefinition->getName()] = [
+      'openApiFileUrls' => $openapi_file_urls,
+      'openApiFiles' => $openapi_files,
+      'entityId' => $entity->id(),
+      'entityType' => $entity_type,
+    ];
+
+    return $elements;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+
+    foreach ($items as $delta => $item) {
+      $elements[$delta] = [
+        // Render out tags for SmartDocs Angular app.
+        // See theme_html_tag().
+        '#type' => 'html_tag',
+        '#tag' => 'app-root',
+        '#value' => $this->t('Loading...'),
+      ];
+    }
+
+    return $elements;
+  }
+
+}

--- a/src/Plugin/Field/FieldFormatter/SmartDocsFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/SmartDocsFormatter.php
@@ -105,9 +105,9 @@ class SmartDocsFormatter extends FileFormatterBase implements ContainerFactoryPl
     /** @var \Drupal\file\Entity\File $file */
     foreach ($this->getEntitiesToView($items, $langcode) as $delta => $file) {
       $openapi_file_urls[] = file_create_url($file->getFileUri());
-      $extension = end(explode(".", $file->getFilename()));
+      $file_extension = pathinfo($file->getFilename(), PATHINFO_EXTENSION);
       $file_data = file_get_contents($file->getFileUri());
-      if ($extension == 'json') {
+      if ($file_extension == 'json') {
         $spec = Json::decode($file_data);
 
         if (!$spec) {

--- a/src/Plugin/Field/FieldFormatter/SmartDocsFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/SmartDocsFormatter.php
@@ -122,41 +122,17 @@ class SmartDocsFormatter extends FileFormatterBase implements ContainerFactoryPl
 
     /** @var \Drupal\file\Entity\File $file */
     foreach ($this->getEntitiesToView($items, $langcode) as $delta => $file) {
-      $file_extension = pathinfo($file->getFilename(), PATHINFO_EXTENSION);
-      $file_data = file_get_contents($file->getFileUri());
-
-      // Decode the file to pass to the javascript file.
-      if ($file_extension == 'json') {
-        $spec = Json::decode($file_data);
-
-        if (!$spec) {
-          $this->loggerFactory->error('Error parsing JSON file ' . $file->getFilename());
-          $this->messenger()->addError($this->t('Error parsing JSON file %filename.', [
-            '%filename' => $file->getFilename(),
-          ]));
-          continue;
-        }
-      }
-      else {
-        try {
-          $spec = Yaml::decode($file_data);
-        }
-        catch (InvalidDataTypeException $e) {
-          $this->loggerFactory->error('Error parsing Yaml file ' . $file->getFilename() . ': ' . $e->getMessage());
-          $this->messenger()->addError($this->t('Error parsing Yaml file %filename: %error', [
-            '%filename' => $file->getFilename(),
-            '%error' => $e->getMessage(),
-          ]));
-          continue;
-        }
-      }
-      $openapi_files[] = $spec;
+      $openapi_files[] = [
+        'fileUrl' => $file->url(),
+        'fileExtension' => pathinfo($file->getFilename(), PATHINFO_EXTENSION),
+      ];
     }
 
     $elements['#attached'] = [
       'library' => [
         'apigee_api_catalog/apigee_api_catalog.smartdocs',
         'apigee_api_catalog/apigee_api_catalog.smartdocs_integration',
+        'apigee_api_catalog/apigee_api_catalog.js_yaml',
       ],
     ];
 

--- a/tests/src/Functional/ApiDocsAdminTest.php
+++ b/tests/src/Functional/ApiDocsAdminTest.php
@@ -95,8 +95,8 @@ class ApiDocsAdminTest extends BrowserTestBase {
     // Get the API Doc admin page.
     $this->drupalGet(Url::fromRoute('entity.apidoc.collection'));
 
-    // No API Docs yet.
-    $assert->elementTextContains('css', $header_selector, 'There are no API Docs yet.');
+    // No API docs yet.
+    $assert->elementTextContains('css', $header_selector, 'There are no API docs yet.');
 
     // User can add entity content.
     $assert->linkExists('Add API Doc');


### PR DESCRIPTION
Fixes #6 
* SmartDocs external javascript libraries added to module
* Added SmartDocs field formatter and javascript to load spec in session storage for SmartDocs angular app
* Changed default field formatter for OpenAPI spec to be SmartDocs
* TODO: Add tests #9