### PR TITLE
DRUP-425:  Remove API Product field

### DIFF
--- a/src/Entity/ApiDoc.php
+++ b/src/Entity/ApiDoc.php
@@ -197,10 +197,8 @@ class ApiDoc extends ContentEntityBase implements ApiDocInterface {
       ->setDisplayOptions('form', [
         'label' => 'hidden',
         'type' => 'file_generic',
-        'weight' => 0,
-      ])
-      ->setDisplayConfigurable('form', TRUE)
-      ->setDisplayConfigurable('view', TRUE);
+      ->setDisplayConfigurable('form', FALSE)
+      ->setDisplayConfigurable('view', FALSE);
 
     $fields['api_product'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('API Product'))


### PR DESCRIPTION
Add product field is not yet set up to do anything. Remove until we do set it up by hiding the field.