### PR TITLE
Redirect to apidoc canonical path on page not found exception

### DIFF
--- a/apigee_api_catalog.services.yml
+++ b/apigee_api_catalog.services.yml
@@ -7,3 +7,9 @@ services:
   apigee_api_catalog.spec_fetcher:
     class: Drupal\apigee_api_catalog\SpecFetcher
     arguments: ['@file_system', '@http_client', '@entity_type.manager', '@string_translation', '@messenger', '@logger.channel.apigee_api_catalog']
+
+  apigee_api_catalog.page_not_found_subscriber:
+    class: Drupal\apigee_api_catalog\EventSubscriber\PageNotFoundEventSubscriber
+    arguments: ['@path.matcher', '@path.validator']
+    tags:
+      - { name: event_subscriber }

--- a/src/EventSubscriber/PageNotFoundEventSubscriber.php
+++ b/src/EventSubscriber/PageNotFoundEventSubscriber.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * Copyright 2018 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_api_catalog\EventSubscriber;
+
+use Drupal\Core\Path\PathMatcherInterface;
+use Drupal\Core\Path\PathValidatorInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Handles not found exceptions for apidoc entities.
+ *
+ * @package Drupal\apigee_api_catalog\EventSubscriber
+ */
+class PageNotFoundEventSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The path validator service.
+   *
+   * @var \Drupal\Core\Path\PathValidatorInterface
+   */
+  protected $pathValidator;
+
+  /**
+   * The patch matcher service.
+   *
+   * @var \Drupal\Core\Path\PathMatcherInterface
+   */
+  protected $pathMatcher;
+
+  /**
+   * PageNotFoundEventSubscriber constructor.
+   *
+   * @param \Drupal\Core\Path\PathMatcherInterface $path_matcher
+   *   The patch matcher service.
+   * @param \Drupal\Core\Path\PathValidatorInterface $path_validator
+   *   The path validator service.
+   */
+  public function __construct(PathMatcherInterface $path_matcher, PathValidatorInterface $path_validator) {
+    $this->pathValidator = $path_validator;
+    $this->pathMatcher = $path_matcher;
+  }
+
+  /**
+   * Redirects to the apidoc canonical route if we have a not found exception.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent $event
+   *   The exception event.
+   */
+  public function onNotFoundException(GetResponseForExceptionEvent $event) {
+    $path = NULL;
+
+    // Check if the request uri matches an apidoc canonical route.
+    // Also check for apidoc valid path.
+    if (!($event->getException() instanceof NotFoundHttpException)
+      || !(($uri = $event->getRequest()->getRequestUri())
+        && ($this->pathMatcher->matchPath($uri, '/api/*/*'))
+        && ([, $prefix, $id] = explode('/', $uri))
+        && ($path = "/api/{$id}")
+        && $this->pathValidator->isValid($path))
+    ) {
+      return;
+    }
+
+    // Redirect to the apidoc.
+    $event->setResponse(new RedirectResponse($path));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[KernelEvents::EXCEPTION][] = ['onNotFoundException', 0];
+    return $events;
+  }
+
+}

--- a/src/EventSubscriber/PageNotFoundEventSubscriber.php
+++ b/src/EventSubscriber/PageNotFoundEventSubscriber.php
@@ -69,22 +69,18 @@ class PageNotFoundEventSubscriber implements EventSubscriberInterface {
    *   The exception event.
    */
   public function onNotFoundException(GetResponseForExceptionEvent $event) {
-    $path = NULL;
-
     // Check if the request uri matches an apidoc canonical route.
     // Also check for apidoc valid path.
-    if (!($event->getException() instanceof NotFoundHttpException)
-      || !(($uri = $event->getRequest()->getRequestUri())
-        && ($this->pathMatcher->matchPath($uri, '/api/*/*'))
-        && ([, $prefix, $id] = explode('/', $uri))
-        && ($path = "/api/{$id}")
-        && $this->pathValidator->isValid($path))
+    if ($event->getException() instanceof NotFoundHttpException
+      && ($uri = $event->getRequest()->getRequestUri())
+      && $this->pathMatcher->matchPath($uri, '/api/*/*')
+      && (list(,, $id) = explode('/', $uri))
+      && ($path = "/api/{$id}")
+      && $this->pathValidator->isValid($path)
     ) {
-      return;
+      // Redirect to the apidoc.
+      $event->setResponse(new RedirectResponse($path));
     }
-
-    // Redirect to the apidoc.
-    $event->setResponse(new RedirectResponse($path));
   }
 
   /**

--- a/tests/src/Kernel/SmartdocRoutingTest.php
+++ b/tests/src/Kernel/SmartdocRoutingTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * Copyright 2019 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+namespace Drupal\Tests\apigee_api_catalog\Kernel;
+
+use Drupal\apigee_api_catalog\Entity\ApiDoc;
+use Drupal\Core\Url;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Tests smartdoc routing compatibility.
+ *
+ * @group apigee_api_catalog
+ */
+class SmartdocRoutingTest extends KernelTestBase {
+
+  use UserCreationTrait;
+
+  protected static $modules = [
+    'user',
+    'system',
+    'apigee_edge',
+    'key',
+    'apigee_api_catalog',
+    'options',
+    'text',
+    'file',
+    'file_link',
+    'filter',
+  ];
+
+  /**
+   * A test doc.
+   *
+   * @var \Drupal\apigee_api_catalog\Entity\ApiDoc
+   */
+  private $apidoc;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('apidoc');
+
+    $this->apidoc = ApiDoc::create([
+      'name' => 'API 1',
+      'description' => 'Test API 1',
+      'spec' => NULL,
+      'api_product' => NULL,
+    ]);
+
+    $this->apidoc->save();
+
+    // Prepare to create a user.
+    $this->installEntitySchema('user');
+    $this->installSchema('system', ['sequences']);
+    $this->installSchema('user', ['users_data']);
+
+    // Rendering an apidoc requires the default filter formats be installed.
+    $this->installConfig(['filter']);
+
+    $user = $this->createUser(['view published apidoc entities']);
+    $this->setCurrentUser($user);
+
+  }
+
+  /**
+   * Tests the route subscriber will redirect from smartdoc routes.
+   */
+  public function testNotFoundSubscriber() {
+    // Tests the normal response.
+    $request = Request::create(Url::fromRoute('entity.apidoc.canonical', ['apidoc' => $this->apidoc->id()])->toString());
+    $response = $this->container->get('http_kernel')->handle($request);
+    static::assertSame(200, $response->getStatusCode());
+    static::assertEmpty($response->headers->get('location'));
+
+    // Test that the smartdoc routes redirect to the canonical route.
+    $request = Request::create('/api/1/1/overview');
+    $response = $this->container->get('http_kernel')->handle($request);
+
+    static::assertSame(302, $response->getStatusCode());
+    static::assertSame('/api/1', $response->headers->get('location'));
+  }
+
+}


### PR DESCRIPTION
Fixes #20 
This is a fix that implements an event subscriber to redirect back to an apidoc canonical page on page not found exception. It checks for `/api/ID/foo/bar` uri and validates `/api/ID` paths and redirect to that.

This can be a temp fix for the page not found issue on apidocs. 

Instead of seeing a page not found on refresh, the user sees the overview for the smartdocs.