### PR TITLE
#36 - Use base_path() instead of hard-coding in base element.

### DIFF
--- a/src/Plugin/Field/FieldFormatter/SmartDocsFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/SmartDocsFormatter.php
@@ -101,7 +101,7 @@ class SmartDocsFormatter extends FileFormatterBase implements ContainerFactoryPl
     $xuacompatible = [
       '#tag' => 'base',
       '#attributes' => [
-        'href' => '/',
+        'href' => base_path(),
       ],
     ];
     $elements['#attached']['html_head'][] = [$xuacompatible, 'base-href'];


### PR DESCRIPTION
Fixes #36.