### PR TITLE
[#25] Display error or success when reimporting spec.

### DIFF
--- a/src/Entity/Form/ApiDocReimportSpecForm.php
+++ b/src/Entity/Form/ApiDocReimportSpecForm.php
@@ -100,8 +100,9 @@ class ApiDocReimportSpecForm extends ContentEntityConfirmFormBase {
     /* @var \Drupal\apigee_api_catalog\Entity\ApiDocInterface $entity */
     $entity = $this->getEntity();
 
-    $needs_save = $this->specFetcher->fetchSpec($entity);
-    if ($needs_save) {
+    $fetch_status = $this->specFetcher->fetchSpec($entity);
+    // If STATUS_ERROR the error is displayed already by the fetchSpec() method.
+    if ($fetch_status != SpecFetcherInterface::STATUS_ERROR) {
       if ($entity->getEntityType()->isRevisionable()) {
         $entity->setNewRevision();
       }
@@ -110,9 +111,6 @@ class ApiDocReimportSpecForm extends ContentEntityConfirmFormBase {
         '%label' => $this->entity->label(),
       ]));
     }
-    // TODO: $needs_save doesn't tell us if something went wrong.
-    // If the file wasn't changed we should notify, if something went wrong, we
-    // should notify what went wrong.
   }
 
 }

--- a/src/SpecFetcherInterface.php
+++ b/src/SpecFetcherInterface.php
@@ -38,19 +38,44 @@ interface SpecFetcherInterface {
   ];
 
   /**
+   * The status when an error happened during the fetch operation.
+   *
+   * @var string
+   */
+  public const STATUS_ERROR = 'status_error';
+
+  /**
+   * The status when a spec update completed successfully.
+   *
+   * @var string
+   */
+  public const STATUS_UPDATED = 'status_updated';
+
+  /**
+   * The status when a spec update finds the remote file unchanged.
+   *
+   * @var string
+   */
+  public const STATUS_UNCHANGED = 'status_unchanged';
+
+  /**
    * Fetch OpenAPI specification file from URL.
    *
-   * Takes care of updating an ApiDoc entity with the updated spec file. If
+   * Takes care of updating an ApiDoc file entity with the updated spec file. If
    * "spec_file_source" uses a URL, it will fetch the specified file and put it
    * in the "spec" file field. If it uses a "file", it won't change it.
+   * This method only updates the file entity if it completed without error (if
+   * it returns STATUS_UPDATED or STATUS_UNCHANGED), it does not save
+   * the ApiDoc entity.
    *
    * @param \Drupal\apigee_api_catalog\Entity\ApiDocInterface $apidoc
    *   The ApiDoc entity.
    *
-   * @return bool
-   *   Returns TRUE if the entity was changed and needs to be saved, FALSE
-   *   otherwise.
+   * @return string
+   *   Returns the status of the operation. If it is STATUS_UPDATED or
+   *   STATUS_UNCHANGED, the ApiDoc entity will need to be saved to store the
+   *   changes.
    */
-  public function fetchSpec(ApiDocInterface $apidoc): bool;
+  public function fetchSpec(ApiDocInterface $apidoc): string;
 
 }


### PR DESCRIPTION
Fixes #25 . The code was only handling `RequestException` but I've made that more generic by handling `GuzzleException`, which is the interface of all exceptions thrown by the HTTP client.