### PR TITLE
Updated ordering of smartdocs libraries

### DIFF
--- a/src/Plugin/Field/FieldFormatter/SmartDocsFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/SmartDocsFormatter.php
@@ -131,8 +131,8 @@ class SmartDocsFormatter extends FileFormatterBase implements ContainerFactoryPl
 
     $elements['#attached'] = [
       'library' => [
-        'apigee_api_catalog/apigee_api_catalog.smartdocs',
         'apigee_api_catalog/apigee_api_catalog.smartdocs_integration',
+        'apigee_api_catalog/apigee_api_catalog.smartdocs',
         'apigee_api_catalog/apigee_api_catalog.js_yaml',
       ],
     ];


### PR DESCRIPTION
Updated ordering of smartdocs libraries to ensure api spec is loaded before rendering. Otherwise on empty localstorage, there's no api spec to be rendered.