### PR TITLE
[#82] Change the names of the library in apigee_api_catalog.libraries.yml

### DIFF
--- a/apigee_api_catalog.libraries.yml
+++ b/apigee_api_catalog.libraries.yml
@@ -1,5 +1,5 @@
 # SmartDocs Drupal Angular application.
-apigee_api_catalog.smartdocs:
+smartdocs:
   version: 1.0.0
   license:
     name: Proprietary Google Code
@@ -17,7 +17,7 @@ apigee_api_catalog.smartdocs:
 
 # Integration of SmartDocs Angular application with Drupal,
 # passes the OpenAPI spec URL to the SmartDocs ng app.
-apigee_api_catalog.smartdocs_integration:
+smartdocs_integration:
   version: VERSION
   js:
     js/smartdocs_integration.js: {}
@@ -26,7 +26,7 @@ apigee_api_catalog.smartdocs_integration:
     - core/drupal
 
 # Library to parse OpenAPI YAML files to pass to SmartDocs Angular app.
-apigee_api_catalog.js_yaml:
+js_yaml:
   version: 3.13.1
   license:
     name: MIT

--- a/src/Plugin/Field/FieldFormatter/SmartDocsFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/SmartDocsFormatter.php
@@ -131,9 +131,9 @@ class SmartDocsFormatter extends FileFormatterBase implements ContainerFactoryPl
 
     $elements['#attached'] = [
       'library' => [
-        'apigee_api_catalog/apigee_api_catalog.js_yaml',
-        'apigee_api_catalog/apigee_api_catalog.smartdocs_integration',
-        'apigee_api_catalog/apigee_api_catalog.smartdocs'
+        'apigee_api_catalog/js_yaml',
+        'apigee_api_catalog/smartdocs_integration',
+        'apigee_api_catalog/smartdocs'
       ],
     ];
 


### PR DESCRIPTION
Closes #82. Will go into 2.x because it's a breaking change.