### PR TITLE
[#94] Bump drupal/file_link requirement from ~1.0 to ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=7.1",
         "drupal/apigee_edge": "~1.0-rc4",
-        "drupal/file_link": "~1.0"
+        "drupal/file_link": "^2.0"
     },
     "require-dev": {
         "drupal/coder": "^8.3",


### PR DESCRIPTION
Reviewed diff and tested update locally. The only change to the module was the way the spaceless filter is applied in the twig templates.