### PR TITLE
[#95] Fix update error from 8.x-1.x

### DIFF
--- a/src/Entity/ApiDoc.php
+++ b/src/Entity/ApiDoc.php
@@ -45,6 +45,10 @@ use Drupal\link\LinkItemInterface;
  *     "views_data" = "Drupal\views\EntityViewsData",
  *     "translation" = "Drupal\content_translation\ContentTranslationHandler",
  *     "access" = "Drupal\apigee_api_catalog\Entity\Access\ApiDocAccessControlHandler",
+ *     "route_provider" = {
+ *       "html" = "Drupal\apigee_api_catalog\Entity\Routing\ApiDocHtmlRouteProvider",
+ *       "revision" = "Drupal\entity\Routing\RevisionRouteProvider",
+ *     },
  *   },
  *   base_table = "apidoc",
  *   data_table = "apidoc_field_data",
@@ -66,7 +70,19 @@ use Drupal\link\LinkItemInterface;
  *     "revision_user" = "revision_user",
  *     "revision_created" = "revision_created",
  *     "revision_log_message" = "revision_log_message",
- *   }
+ *   },
+ *   links = {
+ *     "canonical" = "/api/{apidoc}",
+ *     "add-form" = "/admin/content/api/add",
+ *     "edit-form" = "/admin/content/api/{apidoc}/edit",
+ *     "delete-form" = "/admin/content/api/{apidoc}/delete",
+ *     "reimport-spec-form" = "/admin/content/api/{apidoc}/reimport",
+ *     "version-history" = "/admin/content/api/{apidoc}/revisions",
+ *     "revision" = "/admin/content/api/{apidoc}/revisions/{apidoc_revision}/view",
+ *     "revision-revert-form" = "/admin/content/api/{apidoc}/revisions/{apidoc_revision}/revert",
+ *     "collection" = "/admin/content/apis",
+ *   },
+ *   field_ui_base_route = "entity.apidoc.settings"
  * )
  */
 class ApiDoc extends EditorialContentEntityBase implements ApiDocInterface {

--- a/src/Entity/Routing/ApiDocHtmlRouteProvider.php
+++ b/src/Entity/Routing/ApiDocHtmlRouteProvider.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * Copyright 2019 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_api_catalog\Entity\Routing;
+
+use Drupal\apigee_api_catalog\Controller\ApiDocController;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\Routing\AdminHtmlRouteProvider;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Symfony\Component\Routing\Route;
+
+/**
+ * Provides routes for API Doc entities.
+ *
+ * @deprecated in 2.x and is removed from 3.x. Use the node "apidoc" bundle instead.
+ * @see \Drupal\Core\Entity\Routing\AdminHtmlRouteProvider
+ * @see \Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider
+ */
+class ApiDocHtmlRouteProvider extends AdminHtmlRouteProvider {
+
+  use StringTranslationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRoutes(EntityTypeInterface $entity_type) {
+    $collection = parent::getRoutes($entity_type);
+
+    if ($settings_form_route = $this->getSettingsFormRoute($entity_type)) {
+      $collection->add('entity.apidoc.settings', $settings_form_route);
+    }
+
+    if ($apidoc_collection_route = $collection->get('entity.apidoc.collection')) {
+      $apidoc_collection_route->setDefault('_title', $this->t('@entity_type catalog', ['@entity_type' => $entity_type->getLabel()])->render());
+    }
+
+    if ($reimport_spec_route = $this->getReimportSpecFormRoute($entity_type)) {
+      $collection->add("entity.apidoc.reimport_spec_form", $reimport_spec_route);
+    }
+
+    return $collection;
+  }
+
+  /**
+   * Gets the settings form route.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
+   *   The entity type.
+   *
+   * @return \Symfony\Component\Routing\Route|null
+   *   The generated route, if available.
+   */
+  protected function getSettingsFormRoute(EntityTypeInterface $entity_type) {
+    if (!$entity_type->getBundleEntityType()) {
+      $route = new Route('admin/structure/apidoc');
+      $route
+        ->setDefaults([
+          '_form' => 'Drupal\apigee_api_catalog\Entity\Form\ApiDocSettingsForm',
+          '_title_callback' => ApiDocController::class . '::title',
+        ])
+        ->setRequirement('_permission', $entity_type->getAdminPermission())
+        ->setOption('_admin_route', TRUE);
+
+      return $route;
+    }
+  }
+
+  /**
+   * Gets the reimport-spec-form route.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
+   *   The entity type.
+   *
+   * @return \Symfony\Component\Routing\Route|null
+   *   The generated route, if available.
+   */
+  protected function getReimportSpecFormRoute(EntityTypeInterface $entity_type) {
+    $route = new Route($entity_type->getLinkTemplate('reimport-spec-form'));
+
+    $route
+      ->setDefaults([
+        '_entity_form' => "apidoc.reimport_spec",
+        '_title' => 'Re-import API Doc OpenAPI specification',
+      ])
+      ->setRequirement('_entity_access', "apidoc.reimport")
+      ->setOption('parameters', [
+        'apidoc' => ['type' => 'entity:apidoc'],
+      ]);
+
+    // Entity types with serial IDs can specify this in their route
+    // requirements, improving the matching process.
+    if ($this->getEntityTypeIdKeyType($entity_type) === 'integer') {
+      $route->setRequirement('apidoc', '\d+');
+    }
+
+    return $route;
+  }
+
+}


### PR DESCRIPTION
Fixes #95 by adding back the original API Doc entity route definitions.