### PR TITLE
#102 and #103 Add CI testing, and enable test matrix against D9

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -1,0 +1,4 @@
+# Continuous Integration
+
+Continuous integration for this module has been set up in CircleCI using
+[deviantintegral/drupal_tests](https://github.com/deviantintegral/drupal_tests) as as a base.

--- a/.circleci/RoboFile.php
+++ b/.circleci/RoboFile.php
@@ -466,6 +466,12 @@ class RoboFile extends \Robo\Tasks
         $config->require->{"drupal/core-recommended"} = '^9';
         $config->require->{"drupal/core-dev"} = '^9';
 
+        if (!isset($config->extra->{"patches"}->{"drupal/file_link"})) {
+          $config->extra->{"patches"}->{"drupal/file_link"} = new \stdClass();
+        }
+        $config->extra->{"patches"}->{"drupal/file_link"}
+          ->{"D9 readiness for file_link_test module"} = 'https://www.drupal.org/files/issues/2020-09-26/file-link-test-info-d9-3173363-2.patch';
+
         break;
 
       case '8':

--- a/.circleci/RoboFile.php
+++ b/.circleci/RoboFile.php
@@ -47,6 +47,7 @@ class RoboFile extends \Robo\Tasks
     $config = json_decode(file_get_contents('composer.json'));
     $config->extra->{"enable-patching"} = 'true';
     $config->extra->{"patches"} = new \stdClass();
+    unset($config->require->{"wikimedia/composer-merge-plugin"});
     $config->extra->{"drupal-scaffold"} = new \stdClass();
     $config->extra->{"drupal-scaffold"}->{"locations"} = (object) [
       'web-root' => '.',
@@ -111,6 +112,38 @@ class RoboFile extends \Robo\Tasks
       $base = isset($config->extra->{"patches"}) ?  (array)$config->extra->{"patches"} : [];
       $config->extra->{"patches"} = (object)array_merge($base,
         (array)$this->getPatches($module));
+    }
+
+    file_put_contents('composer.json', json_encode($config));
+  }
+
+  /**
+   * Adds another composer.json requires and requires-dev to this project.
+   *
+   * @param string $composerFilePath
+   *   Path to the composer.json file to merge.
+   */
+  public function addDependenciesFrom(string $composerFilePath)
+  {
+    $config = json_decode(file_get_contents('composer.json'));
+    $additional = json_decode(file_get_contents($composerFilePath));
+
+    if (!empty($additional->require)) {
+      foreach ($additional->require as $key => $value) {
+        if (!isset($config->require->{$key})) {
+          $config->require->{$key} = $value;
+        }
+      }
+    }
+    if (!empty($additional->{"require-dev"})) {
+      foreach ($additional->{"require-dev"} as $key => $value) {
+        if (!isset($config->{"require-dev"}->{$key})) {
+          if (!isset($config->{"require-dev"})) {
+            $config->{"require-dev"} = new \stdClass();
+          }
+          $config->{"require-dev"}->{$key} = $value;
+        }
+      }
     }
 
     file_put_contents('composer.json', json_encode($config));
@@ -489,7 +522,7 @@ class RoboFile extends \Robo\Tasks
 
       // Delete D8 only modules.
       $this->taskFilesystemStack()
-        ->taskDeleteDir('modules/apigee_edge/modules/apigee_edge_actions')
+        ->taskDeleteDir('modules/contrib/apigee_edge/modules/apigee_edge_actions')
         ->run();
     }
   }

--- a/.circleci/RoboFile.php
+++ b/.circleci/RoboFile.php
@@ -1,0 +1,497 @@
+<?php
+
+// @codingStandardsIgnoreStart
+
+/**
+ * Base tasks for setting up a module to test within a full Drupal environment.
+ *
+ * This file expects to be called from within the module directory, and for a
+ * Drupal installation to be located in the parent directory. In other words,
+ * this module should be in /modules and not /sites/all/modules or other
+ * locations.
+ *
+ * @class RoboFile
+ * @codeCoverageIgnore
+ */
+class RoboFile extends \Robo\Tasks
+{
+
+  /**
+   * RoboFile constructor.
+   */
+  public function __construct()
+  {
+    // Treat this command like bash -e and exit as soon as there's a failure.
+    $this->stopOnFail();
+  }
+
+  /**
+   * Files which we don't want to copy into the module directory.
+   */
+  static $excludeFiles = [
+    '.',
+    '..',
+    'vendor',
+    'RoboFile.php',
+    '.git',
+    '.idea',
+  ];
+
+  /**
+   * Set up the Drupal skeleton.
+   */
+  public function setupSkeleton()
+  {
+    // composer config doesn't allow us to set arrays, so we have to do this by
+    // hand.
+    $config = json_decode(file_get_contents('composer.json'));
+    $config->extra->{"enable-patching"} = 'true';
+    $config->extra->{"patches"} = new \stdClass();
+    $config->extra->{"drupal-scaffold"} = new \stdClass();
+    $config->extra->{"drupal-scaffold"}->{"locations"} = (object) [
+      'web-root' => '.',
+    ];
+
+    file_put_contents('composer.json', json_encode($config));
+
+    // Create a directory for our artifacts.
+    $this->taskFilesystemStack()
+      ->mkdir('artifacts')
+      ->mkdir('artifacts/phpcs')
+      ->mkdir('artifacts/phpmd')
+      ->mkdir('artifacts/phpmetrics')
+      ->mkdir('artifacts/d9')
+      ->mkdir('/tmp/artifacts/phpunit')
+      ->mkdir('/tmp/artifacts/phpmd')
+      ->run();
+
+    $this->taskFilesystemStack()
+      ->chown('/tmp/artifacts', 'www-data', TRUE)
+      ->copy('modules/apigee_api_catalog/.circleci/d9.sh', '/var/www/html/d9.sh')
+      ->chmod('/var/www/html/d9.sh', 0777)
+      ->run();
+  }
+
+  /**
+   * Adds coding standard dependencies.
+   */
+  public function addCodingStandardsDeps()
+  {
+    $config = json_decode(file_get_contents('composer.json'));
+    $config->require->{"drupal/coder"} = "^2.0|^8.2";
+    file_put_contents('composer.json', json_encode($config));
+  }
+
+  /**
+   * Adds Behat dependencies.
+   */
+  public function addBehatDeps()
+  {
+    $config = json_decode(file_get_contents('composer.json'));
+    // Package behat/mink-selenium2-driver is included in  drupal/core-dev.
+    $config->require->{"drupal/drupal-extension"} = "master-dev";
+    $config->require->{"guzzlehttp/guzzle"} = "^6.0@dev";
+    file_put_contents('composer.json', json_encode($config));
+  }
+
+  /**
+   * Adds modules to the merge section.
+   *
+   * @param array $modules
+   *   The list of modules.
+   */
+  public function addModules(array $modules)
+  {
+    $config = json_decode(file_get_contents('composer.json'));
+    $config->extra->{"merge-plugin"}->{"ignore-duplicates"} = TRUE;
+
+    foreach ($modules as $module) {
+      list($module,) = explode(':', $module);
+      $config->extra->{"merge-plugin"}->include[] = "modules/$module/composer.json";
+      $base = isset($config->extra->{"patches"}) ?  (array)$config->extra->{"patches"} : [];
+      $config->extra->{"patches"} = (object)array_merge($base,
+        (array)$this->getPatches($module));
+    }
+
+    file_put_contents('composer.json', json_encode($config));
+  }
+
+  /**
+   * Adds contrib modules to the require section.
+   *
+   * @param array $modules
+   *   The list of modules.
+   */
+  public function addContribModules(array $modules)
+  {
+    $config = json_decode(file_get_contents('composer.json'));
+
+    foreach ($modules as $module) {
+      list($module, $version) = explode(':', $module);
+      $config->require->{"drupal/" . $module} = $version;
+    }
+
+    file_put_contents('composer.json', json_encode($config));
+  }
+
+  /**
+   * Updates modules.
+   *
+   * @param array $modules
+   *   The list of modules.
+   */
+  public function updateModules(array $modules)
+  {
+    $config = json_decode(file_get_contents('composer.json'));
+
+    // Rebuild the patches array.
+    $config->extra->{"patches"} = new \stdClass();
+    foreach ($modules as $module) {
+      list($module,) = explode(':', $module);
+      $config->extra->{"patches"} = (object)array_merge((array)$config->extra->{"patches"},
+        (array)$this->getPatches($module));
+    }
+
+    file_put_contents('composer.json', json_encode($config));
+  }
+
+  /**
+   * Updates contrib modules.
+   *
+   * @param array $modules
+   *   The list of modules.
+   */
+  public function updateContribModules(array $modules)
+  {
+    // The implementation is the same as adding modules but for
+    // readability we have this alias when updating sites.
+    $this->addContribModules($modules);
+  }
+
+  /**
+   * Updates composer dependencies.
+   */
+  public function updateDependencies()
+  {
+    // Disable xdebug.
+    $this->taskExec('sed -i \'s/^zend_extension/;zend_extension/g\' /usr/local/etc/php/conf.d/xdebug.ini')
+      ->run();
+
+    // The git checkout includes a composer.lock, and running composer update
+    // on it fails for the first time.
+    $this->taskFilesystemStack()->remove('composer.lock')->run();
+
+    // Remove all core files and vendor.
+    $this->taskFilesystemStack()
+      ->taskDeleteDir('core')
+      ->taskDeleteDir('vendor')
+      ->run();
+
+    // Composer often runs out of memory when installing drupal.
+    $this->taskComposerInstall('php -d memory_limit=-1 /usr/local/bin/composer')
+      ->optimizeAutoloader()
+      ->run();
+
+    // Preserve composer.lock as an artifact for future debugging.
+    $this->taskFilesystemStack()
+      ->copy('composer.json', '/tmp/artifacts/composer.json')
+      ->copy('composer.lock', '/tmp/artifacts/composer.lock')
+      ->run();
+
+    // Write drush status results to an artifact file.
+    $this->taskExec('vendor/bin/drush status > /tmp/artifacts/core-stats.txt')
+      ->run();
+    $this->taskExec('cat /tmp/artifacts/core-stats.txt')
+      ->run();
+
+    // Add php info to an artifact file.
+    $this->taskExec('php -i > /tmp/artifacts/phpinfo.txt')
+      ->run();
+
+    // Add composer version info to an artifact file.
+    $this->taskExec('composer show')
+      ->run();
+    $this->taskExec('composer show > /tmp/artifacts/composer-show.txt')
+      ->run();
+  }
+
+  /**
+   * Returns an array of patches to apply for a given module.
+   *
+   * @param string $module
+   *   The name of the module.
+   *
+   * @return \stdClass
+   *   An object containing a list of patches to apply via Composer Patches.
+   */
+  protected function getPatches($module)
+  {
+    $path = 'modules/' . $module . '/patches.json';
+    if (file_exists($path)) {
+      return json_decode(file_get_contents($path));
+    } else {
+      return new stdClass();
+    }
+  }
+
+  /**
+   * Install Drupal.
+   *
+   * @param array $opts
+   *   (optional) The array of options.
+   */
+  public function setupDrupal($opts = [
+    'admin-user' => null,
+    'admin-password' => null,
+    'site-name' => null,
+    'db-url' => 'mysql://root@127.0.0.1/drupal8',
+  ]
+  ) {
+    $task = $this->drush()
+      ->args('site-install')
+      ->option('yes')
+      ->option('db-url', $opts['db-url'], '=');
+
+    if ($opts['admin-user']) {
+      $task->option('account-name', $admin_user, '=');
+    }
+
+    if ($opts['admin-password']) {
+      $task->option('account-pass', $admin_password, '=');
+    }
+
+    if ($opts['site-name']) {
+      $task->option('site-name', $site_name, '=');
+    }
+
+    // Sending email will fail, so we need to allow this to always pass.
+    $this->stopOnFail(false);
+    $task->run();
+    $this->stopOnFail();
+  }
+
+  /**
+   * Return drush with default arguments.
+   *
+   * @return \Robo\Task\Base\Exec
+   *   A drush exec command.
+   */
+  protected function drush()
+  {
+    // Drush needs an absolute path to the docroot.
+    $docroot = $this->getDocroot();
+    return $this->taskExec('vendor/bin/drush')
+      ->option('root', $docroot, '=');
+  }
+
+  /**
+   * Get the absolute path to the docroot.
+   *
+   * @return string
+   */
+  protected function getDocroot()
+  {
+    $docroot = (getcwd());
+    return $docroot;
+  }
+
+  /**
+   * Overrides phpunit's configuration with module specific one.
+   *
+   * @param string $module
+   *   The module name where phpunit config files may be located.
+   */
+  public function overridePhpunitConfig($module)
+  {
+    $module_path = "modules/$module";
+    // Copy in our custom phpunit.xml.core.dist file.
+    if (file_exists("$module_path/phpunit.core.xml")) {
+      $this->taskFilesystemStack()
+        ->copy("$module_path/phpunit.core.xml", 'core/phpunit.xml')
+        ->run();
+    } elseif (file_exists("$module_path/phpunit.core.xml.dist")) {
+      $this->taskFilesystemStack()
+        ->copy("$module_path/phpunit.core.xml.dist", 'core/phpunit.xml')
+        ->run();
+    }
+  }
+
+  /**
+   * Run PHPUnit and simpletests for the module.
+   *
+   * @param string $module
+   *   The module name.
+   */
+  public function test($module)
+  {
+    $this->phpUnit($module)
+      ->run();
+  }
+
+  /**
+   * Run tests with code coverage reports.
+   *
+   * @param string $module
+   *   The module name.
+   * @param string $report_output_path
+   *   The full path of the report to generate.
+   */
+  public function testCoverage($module, $report_output_path)
+  {
+    $this->phpUnit($module)
+      ->option('coverage-xml', $report_output_path . '/coverage-xml')
+      ->option('coverage-html', $report_output_path . '/coverage-html')
+      ->option('testsuite', 'nonfunctional')
+      ->run();
+  }
+
+  /**
+   * Return a configured phpunit task.
+   *
+   * This will check for PHPUnit configuration first in the module directory.
+   * If no configuration is found, it will fall back to Drupal's core
+   * directory.
+   *
+   * @param string $module
+   *   The module name.
+   *
+   * @return \Robo\Task\Testing\PHPUnit
+   */
+  private function phpUnit($module)
+  {
+    return $this->taskPhpUnit('vendor/bin/phpunit')
+      ->option('verbose')
+      ->option('debug')
+      ->option('log-junit', '/tmp/artifacts/phpunit/phpunit.xml')
+      ->configFile('core')
+      ->group($module);
+  }
+
+  /**
+   * Gathers coding standard statistics from a module.
+   *
+   * @param string $path
+   *   Path were cs.json and cs-practice.json files have been stored
+   *   by the container where phpcs was executed.
+   *
+   * @return string
+   *   A short string with the total violations.
+   */
+  public function extractCodingStandardsStats($path)
+  {
+    $errors = 0;
+    $warnings = 0;
+
+    if (file_exists($path . '/cs.json')) {
+      $stats = json_decode(file_get_contents($path . '/cs.json'));
+      $errors += $stats->totals->errors;
+      $warnings += $stats->totals->warnings;
+    }
+
+    return $errors . ' errors and ' . $warnings . ' warnings.';
+  }
+
+  /**
+   * Gathers code coverage stats from a module.
+   *
+   * @param string $path
+   *   Path to a Clover report file.
+   *
+   * @return string
+   *   A short string with the coverage percentage.
+   */
+  public function extractCoverageStats($path)
+  {
+    if (file_exists($path . '/index.xml')) {
+      $data = file_get_contents($path . '/index.xml');
+      $xml = simplexml_load_string($data);
+      $totals = $xml->project->directory->totals;
+      $lines = (string)$totals->lines['percent'];
+      $methods = (string)$totals->methods['percent'];
+      $classes = (string)$totals->classes['percent'];
+      return 'Lines ' . $lines . ' Methods ' . $methods . ' Classes ' . $classes;
+    } else {
+      return 'Clover report was not found at ' . $path;
+    }
+  }
+
+  /**
+   * Set the Drupal core version.
+   *
+   * @param int $drupalCoreVersion
+   *   The major version of Drupal required.
+   */
+  public function drupalVersion($drupalCoreVersion)
+  {
+    $config = json_decode(file_get_contents('composer.json'));
+
+    unset($config->require->{"drupal/core"});
+
+    switch ($drupalCoreVersion) {
+      case '9':
+        $config->require->{"drupal/core-composer-scaffold"} = '^9';
+        $config->require->{"drupal/core-recommended"} = '^9';
+        $config->require->{"drupal/core-dev"} = '^9';
+
+        break;
+
+      case '8':
+        $config->require->{"drupal/core-composer-scaffold"} = '~8';
+        $config->require->{"drupal/core-recommended"} = '~8';
+        $config->require->{"drupal/core-dev"} = '~8';
+
+        // Add rules for testing apigee_edge_actions (only for D8).
+        $config->require->{"drupal/rules"} = "3.0.0-alpha6";
+
+        // We require Drupal drush and console for some tests.
+        $config->require->{"drupal/console"} = "~1.0";
+
+      default:
+        break;
+    }
+
+    file_put_contents('composer.json', json_encode($config, JSON_PRETTY_PRINT));
+  }
+
+  /**
+   * Adds modules to the merge section.
+   */
+  public function configureModuleDependencies()
+  {
+    $config = json_decode(file_get_contents('composer.json'));
+
+    // If you require core, you must not replace it.
+    unset($config->replace);
+
+    // Unset scripts that delete vendor test directories.
+    unset($config->scripts->{"post-package-install"});
+    unset($config->scripts->{"post-package-update"});
+
+    // You can't merge from a package that is required.
+    foreach ($config->extra->{"merge-plugin"}->include as $index => $merge_entry) {
+      if ($merge_entry === 'core/composer.json') {
+        unset($config->extra->{"merge-plugin"}->include[$index]);
+      }
+    }
+    $config->extra->{"merge-plugin"}->include = array_values($config->extra->{"merge-plugin"}->include);
+
+    file_put_contents('composer.json', json_encode($config, JSON_PRETTY_PRINT));
+  }
+
+  /**
+   * Perform extra tasks per Drupal core version.
+   *
+   * @param int $drupalCoreVersion
+   *   The major version of Drupal required.
+   */
+  public function doExtra($drupalCoreVersion) {
+    if ($drupalCoreVersion > 8) {
+
+      // Delete D8 only modules.
+      $this->taskFilesystemStack()
+        ->taskDeleteDir('modules/apigee_edge/modules/apigee_edge_actions')
+        ->run();
+    }
+  }
+
+}

--- a/.circleci/code-coverage-stats.sh
+++ b/.circleci/code-coverage-stats.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -ex
+
+export SIMPLETEST_BASE_URL="http://localhost"
+export SIMPLETEST_DB="sqlite://localhost//tmp/drupal.sqlite"
+export BROWSERTEST_OUTPUT_DIRECTORY="/var/www/html/sites/simpletest"
+
+if [ ! -f dependencies_updated ]
+then
+  ./update-dependencies.sh $1
+fi
+
+robo override:phpunit-config $1
+
+timeout 60m sudo -E -u www-data robo test:coverage $1 /tmp/artifacts || true
+tar czf artifacts/coverage.tar.gz -C artifacts coverage-html coverage-xml

--- a/.circleci/code-sniffer.sh
+++ b/.circleci/code-sniffer.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -ex
+
+# Runs CodeSniffer checks on a Drupal module.
+
+if [ ! -f dependencies_updated ]
+then
+  ./update-dependencies.sh $1
+fi
+
+# Install dependencies and configure phpcs
+vendor/bin/phpcs --config-set installed_paths vendor/drupal/coder/coder_sniffer
+
+vendor/bin/phpmd modules/$1/src html cleancode,codesize,design,unusedcode --ignore-violations-on-exit --reportfile artifacts/phpmd/index.html
+vendor/bin/phpmetrics --extensions=php,inc,module --report-html=artifacts/phpmetrics --git modules/$1
+
+# Check coding standards
+vendor/bin/phpcs -p -s -n --colors --standard=modules/apigee_api_catalog/phpcs.xml.dist --report=junit --report-junit=artifacts/phpcs/phpcs.xml modules/$1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,7 +245,7 @@ workflows:
           name: update-dependencies-<< matrix.core-version >>
           matrix:
             parameters:
-              core-version: [8, 9]
+              core-version: [ 8 ]
       - run-code-sniffer:
           requires:
             - update-dependencies-8
@@ -256,21 +256,21 @@ workflows:
           name: run-unit-kernel-tests-<< matrix.core-version >>
           matrix:
             parameters:
-              core-version: [8, 9]
+              core-version: [ 8 ]
           requires:
             - update-dependencies-<< matrix.core-version >>
       - run-functional-tests:
           name: run-functional-tests-<< matrix.core-version >>
           matrix:
             parameters:
-              core-version: [8, 9]
+              core-version: [ 8 ]
           requires:
             - update-dependencies-<< matrix.core-version >>
       - run-functional-js-tests:
           name: run-functional-js-tests-<< matrix.core-version >>
           matrix:
             parameters:
-              core-version: [8, 9]
+              core-version: [ 8 ]
           requires:
             - update-dependencies-<< matrix.core-version >>
 #      - run-code-coverage:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,7 +245,7 @@ workflows:
           name: update-dependencies-<< matrix.core-version >>
           matrix:
             parameters:
-              core-version: [ 8 ]
+              core-version: [ 8, 9 ]
       - run-code-sniffer:
           requires:
             - update-dependencies-8
@@ -256,21 +256,21 @@ workflows:
           name: run-unit-kernel-tests-<< matrix.core-version >>
           matrix:
             parameters:
-              core-version: [ 8 ]
+              core-version: [ 8, 9 ]
           requires:
             - update-dependencies-<< matrix.core-version >>
       - run-functional-tests:
           name: run-functional-tests-<< matrix.core-version >>
           matrix:
             parameters:
-              core-version: [ 8 ]
+              core-version: [ 8, 9 ]
           requires:
             - update-dependencies-<< matrix.core-version >>
       - run-functional-js-tests:
           name: run-functional-js-tests-<< matrix.core-version >>
           matrix:
             parameters:
-              core-version: [ 8 ]
+              core-version: [ 8, 9 ]
           requires:
             - update-dependencies-<< matrix.core-version >>
 #      - run-code-coverage:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,279 @@
+# Default configuration file for Drupal modules.
+#
+# Use setup.sh to automate setting this up. Otherwise, to use this in a new
+# module:
+#   1. Copy config.yml to the module's .circleci directory.
+#   2. Change 'latest' in the image tag to the latest tag.
+#   3. Update the working_directory key.
+#   4. Connect CircleCI to the repository through the Circle UI.
+#   5. Set the COMPOSER_AUTH environment variable in Circle to grant access to
+#      any private repositories.
+#   6. Create a status badge embed code in Circle and add it to the README.md.
+#
+# Check https://circleci.com/docs/2.0/language-php/ for more details
+#
+
+version: 2.1
+
+defaults: &defaults
+  docker:
+    # specify the version you desire here (avoid latest except for testing)
+    - image: quay.io/deviantintegral/drupal_tests:0.5.0-drupal87
+
+    - image: selenium/standalone-chrome-debug:3.141.59-neon
+
+    - image: mariadb:10.4
+      environment:
+        MYSQL_ALLOW_EMPTY_PASSWORD: 1
+
+    # Specify service dependencies here if necessary
+    # CircleCI maintains a library of pre-built images
+    # documented at https://circleci.com/docs/2.0/circleci-images/
+    # - image: circleci/mysql:9.4
+
+  # 'checkout' supports a path key, but not on locals where you test with the
+  # circleci CLI tool.
+  # https://discuss.circleci.com/t/bug-circleci-build-command-ignores-checkout-path-config/13004
+  working_directory: /var/www/html/modules/apigee_api_catalog
+
+  parameters:
+    core-version:
+      type: integer
+      default: 8
+
+# YAML does not support merging of lists. That means we can't have a default
+# 'steps' configuration, though we can have defaults for individual step
+# properties.
+
+# We use the composer.json as a way to determine if we can cache our build.
+restore_cache: &restore_cache
+  keys:
+  - v4-dependencies-{{ checksum "composer.json" }}-{{ checksum "../../composer.json" }}
+  # fallback to using the latest cache if no exact match is found
+  - v4-dependencies-
+
+# If composer.json hasn't changed, restore the Composer cache directory. We
+# don't restore the lock file so we ensure we get updated dependencies.
+save_cache: &save_cache
+  paths:
+    - /root/.composer/cache/files
+  key: v4-dependencies-{{ checksum "composer.json" }}-{{ checksum "../../composer.json" }}
+
+# Install composer dependencies into the workspace to share with all jobs.
+update_dependencies: &update_dependencies
+  <<: *defaults
+
+  steps:
+    - print:
+        message: Using Drupal core version << parameters.core-version >>
+
+    - checkout
+
+    - restore_cache: *restore_cache
+
+    - run:
+        working_directory: /var/www/html
+        command: |
+          cp ./modules/apigee_api_catalog/.circleci/update-dependencies.sh /var/www/html
+          ./update-dependencies.sh apigee_api_catalog << parameters.core-version >>
+
+    - save_cache: *save_cache
+
+    - persist_to_workspace:
+        root: /var/www/html
+        paths:
+          - .
+
+    - store_artifacts:
+        path: /tmp/artifacts
+
+# Run Drupal unit and kernel tests as one job. This command invokes the test.sh
+# hook.
+unit_kernel_tests: &unit_kernel_tests
+  <<: *defaults
+  steps:
+    - run: rm -rf /var/www/html/core
+
+    - attach_workspace:
+        at: /var/www/html
+
+    - checkout
+
+    - run:
+        working_directory: /var/www/html
+        command: |
+          cp ./modules/apigee_api_catalog/.circleci/test.sh /var/www/html
+          ./test.sh apigee_api_catalog << parameters.core-version >>
+
+    - store_test_results:
+        path: /tmp/artifacts/phpunit
+    - store_artifacts:
+        path: /tmp/artifacts
+
+# Run Drupal functional tests. This command invokes the test-functional.sh
+# hook.
+functional_tests: &functional_tests
+  <<: *defaults
+  steps:
+    - run: rm -rf /var/www/html/core
+
+    - attach_workspace:
+        at: /var/www/html
+
+    - checkout
+
+    - run:
+        working_directory: /var/www/html
+        command: |
+          cp ./modules/apigee_api_catalog/.circleci/test-functional.sh /var/www/html
+          ./test-functional.sh apigee_api_catalog << parameters.core-version >>
+
+    - store_test_results:
+        path: /tmp/artifacts/phpunit
+    - store_artifacts:
+        path: /tmp/artifacts
+
+# Run Drupal functional tests. This command invokes test-functional-js.sh.
+functional_js_tests: &functional_js_tests
+  <<: *defaults
+  steps:
+    - run: rm -rf /var/www/html/core
+
+    - attach_workspace:
+        at: /var/www/html
+
+    - checkout
+
+    - run:
+        working_directory: /var/www/html
+        command: |
+          cp ./modules/apigee_api_catalog/.circleci/test-functional-js.sh /var/www/html
+          ./test-functional-js.sh apigee_api_catalog << parameters.core-version >>
+
+    - store_test_results:
+        path: /tmp/artifacts/phpunit
+    - store_artifacts:
+        path: /tmp/artifacts
+
+# Run code quality tests. This invokes code-sniffer.sh.
+code_sniffer: &code_sniffer
+  <<: *defaults
+  steps:
+    - attach_workspace:
+        at: /var/www/html
+
+    - checkout
+
+    - run:
+        working_directory: /var/www/html
+        command: |
+          cp ./modules/apigee_api_catalog/.circleci/code-sniffer.sh /var/www/html
+          ./code-sniffer.sh apigee_api_catalog
+
+    - store_test_results:
+        path: /var/www/html/artifacts
+    - store_artifacts:
+        path: /var/www/html/artifacts
+
+# Run code coverage tests. This invokes code-coverage-stats.sh.
+code_coverage: &code_coverage
+  <<: *defaults
+  steps:
+    - attach_workspace:
+        at: /var/www/html
+
+    - checkout
+
+    - run:
+        working_directory: /var/www/html
+        command: |
+          ./code-coverage-stats.sh apigee_api_catalog
+    - store_artifacts:
+        path: /var/www/html/artifacts
+
+# Run D9 deprecation checks.
+d9_check: &d9_check
+  <<: *defaults
+  steps:
+    - attach_workspace:
+        at: /var/www/html
+
+    - checkout
+
+    - run:
+        working_directory: /var/www/html
+        command: |
+          ./d9.sh modules/apigee_api_catalog
+
+    - store_test_results:
+        path: /var/www/html/artifacts/d9
+    - store_artifacts:
+        path: /var/www/html/artifacts/d9
+
+commands:
+  print:
+    parameters:
+      message:
+        type: string
+    steps:
+      - run: echo << parameters.message >>
+
+# Declare all of the jobs we should run.
+jobs:
+  update-dependencies:
+     <<: *update_dependencies
+  run-unit-kernel-tests:
+     <<: *unit_kernel_tests
+  run-functional-tests:
+     <<: *functional_tests
+  run-functional-js-tests:
+     <<: *functional_js_tests
+  run-code-sniffer:
+     <<: *code_sniffer
+  run-code-coverage:
+     <<: *code_coverage
+  run-d9-check:
+     <<: *d9_check
+
+workflows:
+  version: 2
+
+  # Declare a workflow that runs jobs in parallel.
+  test_and_lint:
+    jobs:
+      - update-dependencies:
+          name: update-dependencies-<< matrix.core-version >>
+          matrix:
+            parameters:
+              core-version: [8, 9]
+      - run-code-sniffer:
+          requires:
+            - update-dependencies-8
+      - run-d9-check:
+          requires:
+            - update-dependencies-8
+      - run-unit-kernel-tests:
+          name: run-unit-kernel-tests-<< matrix.core-version >>
+          matrix:
+            parameters:
+              core-version: [8, 9]
+          requires:
+            - update-dependencies-<< matrix.core-version >>
+      - run-functional-tests:
+          name: run-functional-tests-<< matrix.core-version >>
+          matrix:
+            parameters:
+              core-version: [8, 9]
+          requires:
+            - update-dependencies-<< matrix.core-version >>
+      - run-functional-js-tests:
+          name: run-functional-js-tests-<< matrix.core-version >>
+          matrix:
+            parameters:
+              core-version: [8, 9]
+          requires:
+            - update-dependencies-<< matrix.core-version >>
+#      - run-code-coverage:
+#          requires:
+#            - update-dependencies
+#            - run-unit-kernel-tests

--- a/.circleci/d9.sh
+++ b/.circleci/d9.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -ex
+
+if [ ! -f dependencies_updated ]
+then
+  ./update-dependencies.sh $1
+fi
+
+vendor/bin/drupal-check --no-progress --memory-limit=1000M --format=junit $1 > /var/www/html/artifacts/d9/d9check.xml
+

--- a/.circleci/test-functional-js.sh
+++ b/.circleci/test-functional-js.sh
@@ -17,5 +17,6 @@ apache2-foreground&
 
 robo override:phpunit-config $1
 robo do:extra $2
+export SYMFONY_DEPRECATIONS_HELPER=disabled
 
 sudo -E -u www-data vendor/bin/phpunit -c core --group $1 --testsuite functional-javascript --debug --verbose --log-junit /tmp/artifacts/phpunit/phpunit.xml

--- a/.circleci/test-functional-js.sh
+++ b/.circleci/test-functional-js.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -ex
+
+# CI test-functional-js.sh hook implementation.
+
+export SIMPLETEST_BASE_URL="http://localhost"
+export SIMPLETEST_DB="sqlite://localhost//tmp/drupal.sqlite"
+export BROWSERTEST_OUTPUT_DIRECTORY="/var/www/html/sites/simpletest"
+export MINK_DRIVER_ARGS_WEBDRIVER='["chrome", null, "http://localhost:4444/wd/hub"]'
+
+if [ ! -f dependencies_updated ]
+then
+  ./update-dependencies.sh $1 $2
+fi
+
+# This is the command used by the base image to serve Drupal.
+apache2-foreground&
+
+robo override:phpunit-config $1
+robo do:extra $2
+
+sudo -E -u www-data vendor/bin/phpunit -c core --group $1 --testsuite functional-javascript --debug --verbose --log-junit /tmp/artifacts/phpunit/phpunit.xml

--- a/.circleci/test-functional.sh
+++ b/.circleci/test-functional.sh
@@ -16,5 +16,6 @@ apache2-foreground&
 
 robo override:phpunit-config $1
 robo do:extra $2
+export SYMFONY_DEPRECATIONS_HELPER=disabled
 
 sudo -E -u www-data vendor/bin/phpunit -c core --group $1 --testsuite functional --debug --verbose --log-junit /tmp/artifacts/phpunit/phpunit.xml

--- a/.circleci/test-functional.sh
+++ b/.circleci/test-functional.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -ex
+
+# CI test-functional.sh hook implementation.
+
+export SIMPLETEST_BASE_URL="http://localhost"
+export SIMPLETEST_DB="sqlite://localhost//tmp/drupal.sqlite"
+export BROWSERTEST_OUTPUT_DIRECTORY="/var/www/html/sites/simpletest"
+
+if [ ! -f dependencies_updated ]
+then
+  ./update-dependencies.sh $1 $2
+fi
+
+# This is the command used by the base image to serve Drupal.
+apache2-foreground&
+
+robo override:phpunit-config $1
+robo do:extra $2
+
+sudo -E -u www-data vendor/bin/phpunit -c core --group $1 --testsuite functional --debug --verbose --log-junit /tmp/artifacts/phpunit/phpunit.xml

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -ex
+
+# CI test.sh hook implementation.
+
+export SIMPLETEST_BASE_URL="http://localhost"
+export SIMPLETEST_DB="sqlite://localhost//tmp/drupal.sqlite"
+export BROWSERTEST_OUTPUT_DIRECTORY="/var/www/html/sites/simpletest"
+
+if [ ! -f dependencies_updated ]
+then
+  ./update-dependencies.sh $1 $2
+fi
+
+# This is the command used by the base image to serve Drupal.
+apache2-foreground&
+
+robo override:phpunit-config $1
+robo do:extra $2
+composer show
+
+sudo -E -u www-data vendor/bin/phpunit -c core --group $1 --testsuite unit,kernel --debug --verbose --log-junit /tmp/artifacts/phpunit/phpunit.xml

--- a/.circleci/update-dependencies.sh
+++ b/.circleci/update-dependencies.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -ex
+
+# Make sure the robofile is in the correct location.
+cp modules/apigee_api_catalog/.circleci/RoboFile.php ./
+
+robo setup:skeleton
+robo add:modules $1
+robo drupal:version $2
+robo configure:module-dependencies
+robo update:dependencies
+robo do:extra $2
+
+# Touch a flag so we know dependencies have been set. Otherwise, there is no
+# easy way to know this step needs to be done when running circleci locally since
+# it does not support workflows.
+touch dependencies_updated

--- a/.circleci/update-dependencies.sh
+++ b/.circleci/update-dependencies.sh
@@ -4,7 +4,7 @@
 cp modules/apigee_api_catalog/.circleci/RoboFile.php ./
 
 robo setup:skeleton
-robo add:modules $1
+robo add:dependencies-from modules/$1/composer.json
 robo drupal:version $2
 robo configure:module-dependencies
 robo update:dependencies

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "drupal/file_link": "^2.0"
     },
     "require-dev": {
+        "cweagans/composer-patches": "^1.6",
         "drupal/core-dev": "^8.7 || ^9",
         "drush/drush": "^9.0 || ^10.0",
         "mglaman/drupal-check": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,12 @@
         "drupal/file_link": "^2.0"
     },
     "require-dev": {
-        "drupal/coder": "^8.3",
-        "phpmd/phpmd": "^2.6",
-        "phpunit/phpunit": "^6.5"
+        "drupal/core-dev": "^8.7 || ^9",
+        "drush/drush": "^9.0 || ^10.0",
+        "mglaman/drupal-check": "^1.1",
+        "phpmd/phpmd": "2.8.2",
+        "phpmetrics/phpmetrics": "^2.5",
+        "phpstan/phpstan": "0.12.42"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "description": "Apigee API Catalog for Drupal",
     "require": {
         "php": ">=7.1",
+        "drupal/entity": "^1.1",
         "drupal/file_link": "^2.0"
     },
     "require-dev": {

--- a/src/Plugin/Field/FieldFormatter/SmartDocsFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/SmartDocsFormatter.php
@@ -72,7 +72,7 @@ class SmartDocsFormatter extends FileFormatterBase implements ContainerFactoryPl
    */
   public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, $label, $view_mode, array $third_party_settings, LoggerChannelFactoryInterface $loggerFactory) {
     parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
-    $this->loggerFactory = $loggerFactory->get('apigee_api_catalog');;
+    $this->loggerFactory = $loggerFactory->get('apigee_api_catalog');
   }
 
   /**

--- a/src/UpdateService.php
+++ b/src/UpdateService.php
@@ -270,7 +270,10 @@ class UpdateService {
       $values = [
         'type' => 'apidoc',
         'title' => $apidoc->label(),
-        'body' => ['value' => $apidoc->description->value, 'format' => 'full_html'],
+        'body' => [
+          'value' => $apidoc->description->value,
+          'format' => 'full_html',
+        ],
         'status' => $apidoc->status->value,
         'created' => $apidoc->created->value,
         'changed' => $apidoc->changed->value,

--- a/tests/src/Functional/ApiDocsJsonApi.php
+++ b/tests/src/Functional/ApiDocsJsonApi.php
@@ -107,7 +107,10 @@ class ApiDocsJsonApi extends BrowserTestBase {
     $collection_url = Url::fromRoute('jsonapi.node--apidoc.collection')
       ->setAbsolute(TRUE)->toString();
 
-    $this->verifyAccess($account, [$this->apidocPublished, $this->apidocUnpublished], $collection_url);
+    $this->verifyAccess($account, [
+      $this->apidocPublished,
+      $this->apidocUnpublished,
+    ], $collection_url);
   }
 
   /**

--- a/tests/src/Functional/ApiDocsJsonApi.php
+++ b/tests/src/Functional/ApiDocsJsonApi.php
@@ -34,6 +34,11 @@ use GuzzleHttp\RequestOptions;
 class ApiDocsJsonApi extends BrowserTestBase {
 
   /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
    * Modules to enable.
    *
    * @var array

--- a/tests/src/Functional/SmartdocRoutingTest.php
+++ b/tests/src/Functional/SmartdocRoutingTest.php
@@ -33,6 +33,11 @@ class SmartdocRoutingTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
   protected static $modules = [
     'node',
     'path_alias',


### PR DESCRIPTION
Closes #102 and #103 . Add CircleCI testing, with the following steps:
- Code sniffer
- D9 deprecations check
- Kernel tests
- Functional tests
- Functional JavaScript tests

Runs all tests against both D8 and D9.

Needs someone with permission to follow the project on CircleCI (@arunz6161 / @cnovak ): https://app.circleci.com/projects/project-dashboard/github/apigee