### PR TITLE
[#109] Add back deprecated apidoc table to avoid update issues

### DIFF
--- a/apigee_api_catalog.install
+++ b/apigee_api_catalog.install
@@ -115,8 +115,16 @@ function apigee_api_catalog_update_8804(&$sandbox) {
 }
 
 /**
- * Delete API Doc entity definition if updating from 1.x.
+ * Deprecated step.
  */
 function apigee_api_catalog_update_8805() {
-  return \Drupal::service('apigee_api_catalog.updates')->update8805();
+//  return \Drupal::service('apigee_api_catalog.updates')->update8805();
 }
+
+/**
+ * Re-install if needed deprecated API Doc entity definition.
+ */
+function apigee_api_catalog_update_8806() {
+  return \Drupal::service('apigee_api_catalog.updates')->update8806();
+}
+

--- a/src/Entity/Access/ApiDocAccessControlHandler.php
+++ b/src/Entity/Access/ApiDocAccessControlHandler.php
@@ -32,7 +32,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Access controller for the API Doc entity.
- * 
+ *
  * @deprecated in 2.x and is removed from 3.x. Use the node "apidoc" bundle instead.
  * @see https://github.com/apigee/apigee-api-catalog-drupal/pull/84
  *

--- a/src/UpdateService.php
+++ b/src/UpdateService.php
@@ -175,7 +175,7 @@ class UpdateService {
   }
 
   /**
-   * Recreate other fields added to the API Doc entity onto the API Doc node type.
+   * Recreate other fields added to API Doc entity onto the API Doc node type.
    *
    * @return string
    *   A message to display.
@@ -314,6 +314,22 @@ class UpdateService {
     }
 
     return 'The API Doc deprecated entity type has been removed from the system.';
+  }
+
+  /**
+   * Recreate API Doc entity definition.
+   *
+   * Rollback update8805().
+   */
+  public function update8806() {
+    \Drupal::entityTypeManager()->clearCachedDefinitions();
+    $entity_definition_update_manager = \Drupal::entityDefinitionUpdateManager();
+    $entity_definition_update_manager->installEntityType(\Drupal::entityTypeManager()->getDefinition('apidoc'));
+
+    // Clear all caches.
+    drupal_flush_all_caches();
+
+    return 'Installed API Doc deprecated entity type.';
   }
 
   /**


### PR DESCRIPTION
Fixes #109 . Disables previous update step that uninstalls the apidoc entity and table, and adds a new update function that re-installs it (for users that already have this problem).
