### PR TITLE
Allow tests to run against PHP Unit ^9 in D9.

### DIFF
--- a/.circleci/RoboFile.php
+++ b/.circleci/RoboFile.php
@@ -473,6 +473,19 @@ class RoboFile extends \Robo\Tasks
         $config->extra->{"patches"}->{"drupal/file_link"}
           ->{"D9 readiness for file_link_test module"} = 'https://www.drupal.org/files/issues/2020-09-26/file-link-test-info-d9-3173363-2.patch';
 
+        /**
+         * Allow tests to run against PHP Unit ^9.
+         *
+         * @todo Remove once the following issue has been fixed in a stable
+         * release from Drupal Core.
+         *
+         * @see https://www.drupal.org/project/drupal/issues/3186443
+         */
+        if (!isset($config->extra->{"patches"}->{"drupal/core"})) {
+          $config->extra->{"patches"}->{"drupal/core"} = new \stdClass();
+        }
+        $config->extra->{"patches"}->{"drupal/core"}->{"PHPUnit 9.5 Call to undefined method ::getAnnotations()"} = 'https://www.drupal.org/files/issues/2020-12-04/3186443-1.patch';
+
         break;
 
       case '8':

--- a/.circleci/RoboFile.php
+++ b/.circleci/RoboFile.php
@@ -462,9 +462,10 @@ class RoboFile extends \Robo\Tasks
 
     switch ($drupalCoreVersion) {
       case '9':
-        $config->require->{"drupal/core-composer-scaffold"} = '^9';
-        $config->require->{"drupal/core-recommended"} = '^9';
+        $config->require->{"drupal/core-composer-scaffold"} = '^9.1@stable';
+        $config->require->{"drupal/core-recommended"} = '^9.1@stable';
         $config->require->{"drupal/core-dev"} = '^9';
+        $config->require->{"phpspec/prophecy-phpunit"} = '^2';
 
         if (!isset($config->extra->{"patches"}->{"drupal/file_link"})) {
           $config->extra->{"patches"}->{"drupal/file_link"} = new \stdClass();

--- a/phpunit.core.xml.dist
+++ b/phpunit.core.xml.dist
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- This based on Drupal's core phpunit.xml.dist. -->
+<!-- TODO set checkForUnintentionallyCoveredCode="true" once https://www.drupal.org/node/2626832 is resolved. -->
+<!-- PHPUnit expects functional tests to be run with either a privileged user
+ or your current system user. See core/tests/README.md and
+ https://www.drupal.org/node/2116263 for details.
+-->
+<phpunit bootstrap="tests/bootstrap.php" colors="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutChangesToGlobalState="true"
+         printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter">
+  <php>
+    <!-- Set error reporting to E_ALL. -->
+    <ini name="error_reporting" value="32767"/>
+    <!-- Do not limit the amount of memory tests take to run. -->
+    <ini name="memory_limit" value="-1"/>
+    <!-- Example SIMPLETEST_BASE_URL value: http://localhost -->
+    <env name="SIMPLETEST_BASE_URL" value=""/>
+    <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
+    <env name="SIMPLETEST_DB" value=""/>
+    <!-- Example SIMPLETEST_IGNORE_DIRECTORIES value: build,dev_module -->
+    <env name="SIMPLETEST_IGNORE_DIRECTORIES" value=""/>
+    <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->
+    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value=""/>
+    <!-- To have browsertest output use an alternative base URL. For example if
+     SIMPLETEST_BASE_URL is an internal DDEV URL, you can set this to the
+     external DDev URL so you can follow the links directly.
+    -->
+    <env name="BROWSERTEST_OUTPUT_BASE_URL" value=""/>
+    <!-- To disable deprecation testing completely uncomment the next line. -->
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
+    <!-- Example for changing the driver class for mink tests MINK_DRIVER_CLASS value: 'Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver' -->
+    <env name="MINK_DRIVER_CLASS" value=''/>
+    <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
+    <env name="MINK_DRIVER_ARGS" value=''/>
+    <!-- Example for changing the driver args to phantomjs tests MINK_DRIVER_ARGS_PHANTOMJS value: '["http://127.0.0.1:8510"]' -->
+    <env name="MINK_DRIVER_ARGS_PHANTOMJS" value=''/>
+    <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["chrome", { "chromeOptions": { "w3c": false } }, "http://localhost:4444/wd/hub"]' For using the Firefox browser, replace "chrome" with "firefox" -->
+    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value=''/>
+  </php>
+  <testsuites>
+    <testsuite name="unit">
+      <file>./tests/TestSuites/UnitTestSuite.php</file>
+    </testsuite>
+    <testsuite name="kernel">
+      <file>./tests/TestSuites/KernelTestSuite.php</file>
+    </testsuite>
+    <testsuite name="functional">
+      <file>./tests/TestSuites/FunctionalTestSuite.php</file>
+    </testsuite>
+    <testsuite name="functional-javascript">
+      <file>./tests/TestSuites/FunctionalJavascriptTestSuite.php</file>
+    </testsuite>
+    <testsuite name="build">
+      <file>./tests/TestSuites/BuildTestSuite.php</file>
+    </testsuite>
+  </testsuites>
+  <listeners>
+    <listener class="\Drupal\Tests\Listeners\DrupalListener">
+    </listener>
+    <!-- The Symfony deprecation listener has to come after the Drupal listener -->
+    <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener">
+    </listener>
+  </listeners>
+  <!-- Filter for coverage reports. -->
+  <filter>
+    <whitelist>
+      <directory>./includes</directory>
+      <directory>./lib</directory>
+      <!-- Extensions can have their own test directories, so exclude those. -->
+      <directory>./modules</directory>
+      <exclude>
+        <directory>./modules/*/src/Tests</directory>
+        <directory>./modules/*/tests</directory>
+      </exclude>
+      <directory>../modules</directory>
+      <exclude>
+        <directory>../modules/*/src/Tests</directory>
+        <directory>../modules/*/tests</directory>
+        <directory>../modules/*/*/src/Tests</directory>
+        <directory>../modules/*/*/tests</directory>
+      </exclude>
+      <directory>../sites</directory>
+     </whitelist>
+  </filter>
+</phpunit>


### PR DESCRIPTION
Tests are failing for D9 with this error:
```
Fatal error: Trait 'Prophecy\PhpUnit\ProphecyTrait' not found in /var/www/html/core/tests/Drupal/TestTools/PhpUnitCompatibility/PhpUnit9/TestCompatibilityTrait.php on line 12
```
This happens since Drupal 9.1 because of this [core change record](https://www.drupal.org/node/3176567).
This PR adds `phpspec/prophecy-phpunit:^2` to the D9 CI dependencies for the tests to run properly.