### PR TITLE
[#116] API Doc "Specification source type" field should not be required

### DIFF
--- a/apigee_api_catalog.install
+++ b/apigee_api_catalog.install
@@ -128,3 +128,9 @@ function apigee_api_catalog_update_8806() {
   return \Drupal::service('apigee_api_catalog.updates')->update8806();
 }
 
+/**
+ * Removed required atttribute for field_apidoc_spec_file_source.
+ */
+function apigee_api_catalog_update_8807() {
+  return \Drupal::service('apigee_api_catalog.updates')->update8807();
+}

--- a/config/install/field.field.node.apidoc.field_apidoc_spec_file_source.yml
+++ b/config/install/field.field.node.apidoc.field_apidoc_spec_file_source.yml
@@ -12,7 +12,7 @@ entity_type: node
 bundle: apidoc
 label: 'Specification source type'
 description: 'Indicate if the OpenAPI spec will be provided as a file for upload or a URL.'
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/src/UpdateService.php
+++ b/src/UpdateService.php
@@ -333,6 +333,20 @@ class UpdateService {
   }
 
   /**
+   * This will set the field field_apidoc_spec_file_source as not required.
+   */
+  public function update8807() {
+    $field = FieldConfig::loadByName('node', 'apidoc', 'field_apidoc_spec_file_source');
+    $field->set('required', FALSE)
+      ->save();
+
+    // Clear all caches.
+    drupal_flush_all_caches();
+
+    return 'Updated field_apidoc_spec_file_source required attribute to false.';
+  }
+
+  /**
    * Get the field map from apidoc fields to node fields.
    *
    * @return array


### PR DESCRIPTION
This PR removes the required attribute for the "Specification source type" field and is now able to create an API Doc without an attached OpenAPI specification. 
Fixes #116 