### PR TITLE
Closes #127 Machine names have a maximum length of 32 characters

### DIFF
--- a/src/UpdateService.php
+++ b/src/UpdateService.php
@@ -195,7 +195,8 @@ class UpdateService {
       if (substr($fieldName, 0, 6) === 'field_') {
 
         // Namespace this custom field to avoid collisions.
-        $newFieldName = $fieldName . '_apidoc';
+        // Machine names have a maximum length of 32 characters https://www.drupal.org/node/2232665
+        $newFieldName = substr($fieldName . '_apidoc', 0, 32);
 
         if (!FieldStorageConfig::loadByName('node', $newFieldName)) {
           $fieldStorageConfig->create([


### PR DESCRIPTION
Machine names have a maximum length of 32 characters https://www.drupal.org/node/2232665