### PR TITLE
Removed config setting for API doc which is converted to a node type

### DIFF
--- a/apigee_api_catalog.info.yml
+++ b/apigee_api_catalog.info.yml
@@ -3,7 +3,6 @@ type: module
 description: 'Display OpenAPI documentation of your APIs to your developers.'
 core_version_requirement: ^8.8.0 || ^9
 package: 'Apigee'
-configure: entity.apidoc.settings
 dependencies:
 - drupal:text
 - drupal:file

--- a/apigee_api_catalog.module
+++ b/apigee_api_catalog.module
@@ -196,7 +196,7 @@ function _apigee_api_catalog_form_node_form_validate(&$form, FormStateInterface 
     return;
   }
 
-  // Make sure the field_apidoc_spec (file) or field_apidoc_file_link (link)
+  // Make sure the field_apidoc_spec (file) or field_apidoc_file_link(link)
   // is not empty, according to what was selected as the file source.
   $source = $values['field_apidoc_spec_file_source'][0]['value'] ?: NULL;
   if ($source == SpecFetcherInterface::SPEC_AS_FILE && empty($values['field_apidoc_spec'][0]['fids'][0])) {

--- a/apigee_api_catalog.module
+++ b/apigee_api_catalog.module
@@ -196,7 +196,7 @@ function _apigee_api_catalog_form_node_form_validate(&$form, FormStateInterface 
     return;
   }
 
-  // Make sure the field_apidoc_spec (file) or field_apidoc_file_link(link)
+  // Make sure the field_apidoc_spec (file) or field_apidoc_file_link (link)
   // is not empty, according to what was selected as the file source.
   $source = $values['field_apidoc_spec_file_source'][0]['value'] ?: NULL;
   if ($source == SpecFetcherInterface::SPEC_AS_FILE && empty($values['field_apidoc_spec'][0]['fids'][0])) {


### PR DESCRIPTION
Closes #122 
This PR removes the config setting for API doc as API doc is converted to node
See https://github.com/apigee/apigee-api-catalog-drupal/pull/84
`entity.apidoc.settings` was removed from links/routes but config setting was not removed which was causing error.