### PR TITLE
Removed the yml extension from field_apidoc_file_link and field_apidoc_spec allowed values

### DIFF
--- a/apigee_api_catalog.install
+++ b/apigee_api_catalog.install
@@ -134,3 +134,10 @@ function apigee_api_catalog_update_8806() {
 function apigee_api_catalog_update_8807() {
   return \Drupal::service('apigee_api_catalog.updates')->update8807();
 }
+
+/**
+ * Removed yml extension from field_apidoc_file_link and field_apidoc_spec allowed values.
+ */
+function apigee_api_catalog_update_8808() {
+  return \Drupal::service('apigee_api_catalog.updates')->update8808();
+}

--- a/config/install/field.field.node.apidoc.field_apidoc_file_link.yml
+++ b/config/install/field.field.node.apidoc.field_apidoc_file_link.yml
@@ -19,6 +19,6 @@ default_value_callback: ''
 settings:
   link_type: 17
   title: 0
-  file_extensions: 'yml yaml json'
+  file_extensions: 'yaml json'
   no_extension: false
 field_type: file_link

--- a/config/install/field.field.node.apidoc.field_apidoc_spec.yml
+++ b/config/install/field.field.node.apidoc.field_apidoc_spec.yml
@@ -18,7 +18,7 @@ default_value: {  }
 default_value_callback: ''
 settings:
   file_directory: apidoc_specs
-  file_extensions: 'yml yaml json'
+  file_extensions: 'yaml json'
   max_filesize: ''
   description_field: false
   handler: 'default:file'

--- a/src/Entity/ApiDoc.php
+++ b/src/Entity/ApiDoc.php
@@ -258,7 +258,7 @@ class ApiDoc extends EditorialContentEntityBase implements ApiDocInterface {
       ->setRevisionable(TRUE)
       ->setSettings([
         'file_directory' => 'apidoc_specs',
-        'file_extensions' => 'yml yaml json',
+        'file_extensions' => 'yaml json',
         'handler' => 'default:file',
         'text_processing' => 0,
       ])
@@ -279,7 +279,7 @@ class ApiDoc extends EditorialContentEntityBase implements ApiDocInterface {
       ->setDescription(t('The URL to an OpenAPI file spec.'))
       ->addConstraint('ApiDocFileLink')
       ->setSettings([
-        'file_extensions' => 'yml yaml json',
+        'file_extensions' => 'yaml json',
         'link_type' => LinkItemInterface::LINK_GENERIC,
         'title' => DRUPAL_DISABLED,
       ])

--- a/src/UpdateService.php
+++ b/src/UpdateService.php
@@ -348,6 +348,29 @@ class UpdateService {
   }
 
   /**
+   * Removed .yml file upload for security reasons.
+   */
+  public function update8808() {
+    $fields = [
+      'field_apidoc_file_link',
+      'field_apidoc_spec',
+    ];
+
+    foreach ($fields as $field) {
+      $fieldConfig = FieldConfig::loadByName('node', 'apidoc', $field);
+      // Only look for yml extension.
+      $extensions = $fieldConfig->getSetting('file_extensions');
+      if (strpos($extensions, 'yml') !== FALSE) {
+        // Remove yml extension from allowed values.
+        $fieldConfig->setSetting('file_extensions', 'yaml json')
+          ->save();
+      }
+    }
+
+    return 'Removed the yml extension from field_apidoc_file_link and field_apidoc_spec allowed values for security reasons.';
+  }
+
+  /**
    * Get the field map from apidoc fields to node fields.
    *
    * @return array


### PR DESCRIPTION
Closes #152 

Removed `.yml` extension from `field_apidoc_file_link` and `field_apidoc_spec` allowed values because in Drupal 8+ `.yml` can contain sensitive information which can cause security issues.

