### PR TITLE
Fix deprecated method assertEqual which is removed from Drupal:10.0.0

### DIFF
--- a/tests/src/Functional/ApiDocsJsonApi.php
+++ b/tests/src/Functional/ApiDocsJsonApi.php
@@ -214,7 +214,7 @@ class ApiDocsJsonApi extends BrowserTestBase {
       return strcmp($a['attributes']['title'], $b['attributes']['title']);
     });
     for ($i = 0; $i < count($apidocs_response); $i++) {
-      $this->assertEqual($apidocs_expected[$i]->label(), $apidocs_response[$i]['attributes']['title']);
+      $this->assertEquals($apidocs_expected[$i]->label(), $apidocs_response[$i]['attributes']['title']);
     }
     // Make sure the count is the same.
     $this->assertCount(count($apidocs_expected), $apidocs_response, 'Count of API Docs returned does not match count of expected.');

--- a/tests/src/Functional/SmartdocRoutingTest.php
+++ b/tests/src/Functional/SmartdocRoutingTest.php
@@ -79,12 +79,12 @@ class SmartdocRoutingTest extends BrowserTestBase {
    * Tests the route subscriber will redirect from smartdoc routes.
    */
   public function testNotFoundSubscriber() {
-    $this->assertEqual($this->apidoc->id(), 1);
+    $this->assertEquals($this->apidoc->id(), 1);
 
     // This needs to run before the alias can be picked up?
     $this->apidoc->toUrl()->toString();
     $alias = \Drupal::service('path_alias.manager')->getAliasByPath('/node/1', $this->apidoc->language()->getId());
-    $this->assertEqual($alias, '/api/1');
+    $this->assertEquals($alias, '/api/1');
 
     $assert = $this->assertSession();
 
@@ -95,7 +95,7 @@ class SmartdocRoutingTest extends BrowserTestBase {
     static::assertEmpty($this->getSession()->getResponseHeader('location'));
 
     // Test the canonical route uses the /api/* path alias.
-    $this->assertEqual(parse_url($this->getSession()->getCurrentUrl(), PHP_URL_PATH), '/api/1');
+    $this->assertEquals(parse_url($this->getSession()->getCurrentUrl(), PHP_URL_PATH), '/api/1');
 
     // Tests the node alias response.
     $this->drupalGet('/api/1');
@@ -107,8 +107,8 @@ class SmartdocRoutingTest extends BrowserTestBase {
     $response = $this->getHttpClient()->request('GET', $url->toString(), [
       'allow_redirects' => FALSE,
     ]);
-    $this->assertEqual($response->getStatusCode(), 302);
-    $this->assertEqual($response->getHeader('location')[0], '/api/1');
+    $this->assertEquals($response->getStatusCode(), 302);
+    $this->assertEquals($response->getHeader('location')[0], '/api/1');
   }
 
 }

--- a/tests/src/Kernel/ApidocEntityTest.php
+++ b/tests/src/Kernel/ApidocEntityTest.php
@@ -104,7 +104,7 @@ class ApidocEntityTest extends KernelTestBase {
     // This needs to run before the alias can be picked up?
     $entity->toUrl()->toString();
     $alias = \Drupal::service('path_alias.manager')->getAliasByPath('/node/' . $entity->id(), $entity->language()->getId());
-    $this->assertEqual($alias, '/api/' . $entity->id());
+    $this->assertEquals($alias, '/api/' . $entity->id());
 
     $entity->delete();
     $this->assertNull($this->nodeStorage->load($entity_id));


### PR DESCRIPTION
Closes #177
Fix deprecated method assertEqual which is removed from Drupal:10.0.0
https://www.drupal.org/project/config_actions/issues/3170479