### PR TITLE
Fix deprecated method drupal_get_path in Drupal:9.3.0 and is removed from Drupal:10.0.0

### DIFF
--- a/src/UpdateService.php
+++ b/src/UpdateService.php
@@ -105,7 +105,7 @@ class UpdateService {
    */
   public function update8802() {
     $module = 'apigee_api_catalog';
-    $configPath = drupal_get_path('module', $module) . '/config';
+    $configPath = \Drupal::service('extension.list.module')->getPath($module) . '/config';
     $configToImport['install'] = [
       'node.type.apidoc',
       'core.base_field_override.node.apidoc.title',
@@ -354,7 +354,7 @@ class UpdateService {
    */
   public function update8808() {
     $module = 'apigee_api_catalog';
-    $configPath = drupal_get_path('module', $module) . '/config';
+    $configPath = \Drupal::service('extension.list.module')->getPath($module) . '/config';
     $configToImport['install'] = [
       'node.type.apidoc',
       'field.field.node.apidoc.field_api_product',


### PR DESCRIPTION
Closes #178 

Fix deprecated method `drupal_get_path()` in Drupal:9.3.0 and is removed from Drupal:10.0.0
see https://www.drupal.org/node/2940438