### PR TITLE
Fix deprecated function file_save_data(): in Drupal:9.3.0 and is removed from Drupal:10.0.0

### DIFF
--- a/src/SpecFetcher.php
+++ b/src/SpecFetcher.php
@@ -172,7 +172,7 @@ class SpecFetcher implements SpecFetcherInterface {
 
         try {
           $this->checkRequirements($destination);
-          $file = file_save_data($data, $destination . $filename, FileSystemInterface::EXISTS_RENAME);
+          $file = \Drupal::service('file.repository')->writeData($data, $destination . $filename, FileSystemInterface::EXISTS_RENAME);
 
           if (empty($file)) {
             throw new \Exception('Could not save API Doc specification file.');


### PR DESCRIPTION
Closes #179 

Fix deprecated function file_save_data(): in Drupal:9.3.0 and is removed from Drupal:10.0.0
See https://www.drupal.org/node/3223520