### PR TITLE
Fixes PHPCS issues

### DIFF
--- a/modules/apigee_graphql_doc/src/Controller/ApigeeGraphqlServerController.php
+++ b/modules/apigee_graphql_doc/src/Controller/ApigeeGraphqlServerController.php
@@ -29,9 +29,6 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\file\Entity\File;
 use Drupal\node\NodeInterface;
 use GraphQL\GraphQL;
-use GraphQL\Type\Definition\ObjectType;
-use GraphQL\Type\Definition\Type;
-use GraphQL\Type\Schema;
 use GraphQL\Utils\BuildSchema;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
@@ -55,7 +52,7 @@ class ApigeeGraphqlServerController extends ControllerBase {
       $field_graphql_spec = $node->get('field_graphql_spec');
 
       if ($field_graphql_spec && $field_graphql_spec->target_id) {
-        /* @var \Drupal\file\Entity\File $file */
+        /** @var \Drupal\file\Entity\File $file */
         $file = File::load($field_graphql_spec->target_id);
 
         if ($file) {

--- a/modules/apigee_graphql_doc/src/Plugin/Field/FieldFormatter/GraphiqlFormatter.php
+++ b/modules/apigee_graphql_doc/src/Plugin/Field/FieldFormatter/GraphiqlFormatter.php
@@ -92,9 +92,9 @@ class GraphiqlFormatter extends FormatterBase {
           'apigeeGraphqlDocFormatter' => [
             $this->fieldDefinition->getName() => [
               'graphqlUrls' => $graphql_urls,
-            ]
-          ]
-        ]
+            ],
+          ],
+        ],
       ];
     }
     return $element;

--- a/src/Entity/Form/ApiDocReimportSpecForm.php
+++ b/src/Entity/Form/ApiDocReimportSpecForm.php
@@ -19,7 +19,6 @@
 
 namespace Drupal\apigee_api_catalog\Entity\Form;
 
-use Drupal\apigee_api_catalog\SpecFetcherInterface;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\ContentEntityConfirmFormBase;
@@ -30,6 +29,7 @@ use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
+use Drupal\apigee_api_catalog\SpecFetcherInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -135,7 +135,7 @@ class ApiDocReimportSpecForm extends ContentEntityConfirmFormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    /* @var \Drupal\node\NodeInterface $entity */
+    /** @var \Drupal\node\NodeInterface $entity */
     $entity = $this->getEntity();
 
     if ($entity->get('field_apidoc_spec_file_source')->value != SpecFetcherInterface::SPEC_AS_URL) {

--- a/src/Plugin/Field/FieldFormatter/SmartDocsFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/SmartDocsFormatter.php
@@ -19,13 +19,10 @@
 
 namespace Drupal\apigee_api_catalog\Plugin\Field\FieldFormatter;
 
-use Drupal\Component\Serialization\Exception\InvalidDataTypeException;
-use Drupal\Component\Serialization\Json;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\Core\Serialization\Yaml;
 use Drupal\file\Plugin\Field\FieldFormatter\FileFormatterBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -133,7 +130,7 @@ class SmartDocsFormatter extends FileFormatterBase implements ContainerFactoryPl
       'library' => [
         'apigee_api_catalog/js_yaml',
         'apigee_api_catalog/smartdocs_integration',
-        'apigee_api_catalog/smartdocs'
+        'apigee_api_catalog/smartdocs',
       ],
     ];
 

--- a/src/Plugin/Validation/Constraint/ApiDocFileLinkConstraintValidator.php
+++ b/src/Plugin/Validation/Constraint/ApiDocFileLinkConstraintValidator.php
@@ -88,7 +88,7 @@ class ApiDocFileLinkConstraintValidator extends ConstraintValidator implements C
         ];
 
         // Perform only a HEAD method to save bandwidth.
-        /* @var $response \Psr\Http\Message\ResponseInterface */
+        /** @var \Psr\Http\Message\ResponseInterface $response */
         $response = $this->httpClient->head($url, $options);
       }
       catch (RequestException $request_exception) {

--- a/src/SpecFetcher.php
+++ b/src/SpecFetcher.php
@@ -32,8 +32,8 @@ use Drupal\node\NodeInterface;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Request;
-use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class SpecFetcher.
@@ -108,7 +108,7 @@ class SpecFetcher implements SpecFetcherInterface {
     if ($apidoc->get('field_apidoc_spec_file_source')->value === static::SPEC_AS_URL) {
 
       // If the file_link field is empty, return without changes.
-      // TODO: The file link shouldn't be empty. Consider throwing an error.
+      // @todo The file link shouldn't be empty. Consider throwing an error.
       if ($apidoc->get('field_apidoc_file_link')->isEmpty()) {
         return FALSE;
       }

--- a/src/UpdateService.php
+++ b/src/UpdateService.php
@@ -28,7 +28,6 @@ use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityLastInstalledSchemaRepositoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
-use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Utility\UpdateException;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;

--- a/tests/src/Functional/ApiDocsAdminTest.php
+++ b/tests/src/Functional/ApiDocsAdminTest.php
@@ -22,10 +22,10 @@ namespace Drupal\Tests\apigee_api_catalog\Functional;
 
 use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Core\Url;
-use Drupal\file\Entity\File;
-use Drupal\file\FileInterface;
 use Drupal\Tests\BrowserTestBase;
 use Drupal\Tests\TestFileCreationTrait;
+use Drupal\file\Entity\File;
+use Drupal\file\FileInterface;
 
 /**
  * Simple test to ensure that main page loads with module enabled.
@@ -50,7 +50,7 @@ class ApiDocsAdminTest extends BrowserTestBase {
     'views',
     'apigee_api_catalog',
     'block',
-    'field_ui'
+    'field_ui',
   ];
 
   /**
@@ -144,7 +144,7 @@ class ApiDocsAdminTest extends BrowserTestBase {
     $assert->pageTextContains(new FormattableMarkup(
         'OpenAPI Doc @name has been created.',
         [
-          '@name' => $random_name
+          '@name' => $random_name,
         ]
       )
     );

--- a/tests/src/Kernel/ApidocEntityTest.php
+++ b/tests/src/Kernel/ApidocEntityTest.php
@@ -114,7 +114,7 @@ class ApidocEntityTest extends KernelTestBase {
    * Test revisioning functionality on an apidocs entity.
    */
   public function testRevisions() {
-    /* @var \Drupal\node\NodeInterface $entity */
+    /** @var \Drupal\node\NodeInterface $entity */
 
     $description_v1 = 'Test API';
     $entity = $this->nodeStorage->create([


### PR DESCRIPTION
PHPCS fix includes the following fixes

1. Use statement sort in alphabetically order
2. Parameter has null default value, but is not marked as nullable.