### PR TITLE
Changes for Drupal 11 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,19 +5,19 @@
     "description": "Apigee API Catalog for Drupal",
     "require": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-        "drupal/entity": "^1.1",
+        "drupal/entity": "^1.6",
         "drupal/file_link": "^2.0",
-        "drupal/apigee_edge": "^3.0.8",
-        "webonyx/graphql-php": "^14.11"
+        "drupal/apigee_edge": "^3.0.8 || ^4.0.0",
+        "webonyx/graphql-php": "^15.19"
     },
     "require-dev": {
-        "cweagans/composer-patches": "^1.6",
-        "drupal/core-dev": "^10.2",
-        "drush/drush": "^12.4.3",
-        "mglaman/drupal-check": "^1.3",
-        "phpmd/phpmd": "^2.8.2",
-        "phpmetrics/phpmetrics": "^2.5",
-        "phpstan/phpstan": "^1.5"
+        "cweagans/composer-patches": "^1.7",
+        "drupal/core-dev": "^10.3 || ^11.1",
+        "drush/drush": "^13.3.3",
+        "mglaman/drupal-check": "^1.5",
+        "phpmd/phpmd": "^2.15.0",
+        "phpmetrics/phpmetrics": "^2.8",
+        "phpstan/phpstan": "^2.1.6"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
Fixes #266 

"drupal/file_link": "^2.0" is not compatible for D11

Here we have [Automated Drupal 11 compatibility fixes for file_link](https://www.drupal.org/project/file_link/issues/3430560) 