### PR TITLE
Fix SmartDocs race condition - make spec loading synchronous

### DIFF
--- a/js/smartdocs_integration.js
+++ b/js/smartdocs_integration.js
@@ -11,6 +11,8 @@
   Drupal.behaviors.smartdocsFieldFormatter = {
     attach: function (context) {
       let specMap = {};
+      let pendingRequests = 0;
+
       for (let fieldName in drupalSettings.smartdocsFieldFormatter) {
         if (drupalSettings.smartdocsFieldFormatter.hasOwnProperty(fieldName)) {
           const field = drupalSettings.smartdocsFieldFormatter[fieldName];
@@ -18,18 +20,29 @@
             // Each openApiFile var has the spec url and file extension.
             const fileUrl = field.openApiFiles[fieldDelta].fileUrl;
             const fileExtention = field.openApiFiles[fieldDelta].fileExtension;
+
+            // Track pending AJAX requests
+            pendingRequests++;
+
             // Get the OpenAPI spec file from the server.
-            $.get(fileUrl, function(data, status) {
-              if (fileExtention === 'json') {
-                // JSON files do not need any conversion.
-                specMap[field.entityId] = data;
+            $.ajax({
+              url: fileUrl,
+              async: false, // Make synchronous to ensure data loads before SmartDocs initializes
+              success: function(data, status) {
+                if (fileExtention === 'json') {
+                  // JSON files do not need any conversion.
+                  specMap[field.entityId] = data;
+                }
+                else {
+                  // YAML files need to be parsed into javascript object.
+                  specMap[field.entityId]  = jsyaml.load(data);
+                }
+                // Store the spec into session storage.
+                sessionStorage.setItem('specs', JSON.stringify(specMap));
+              },
+              complete: function() {
+                pendingRequests--;
               }
-              else {
-                // YAML files need to be parsed into javascript object.
-                specMap[field.entityId]  = jsyaml.load(data);
-             }
-              // Store the spec into session storage.
-              sessionStorage.setItem('specs', JSON.stringify(specMap));
             });
           }
         }


### PR DESCRIPTION
The SmartDocs formatter was using an asynchronous AJAX call ($.get) to fetch OpenAPI specifications. This created a race condition where the SmartDocs Angular application would initialize and check sessionStorage before the spec data had finished loading, resulting in empty/blank API documentation on the first page load. On subsequent loads, the cached sessionStorage data from the previous visit would be available, making the documentation display correctly.

This fix changes the AJAX call to synchronous ($.ajax with async: false) to ensure the OpenAPI specification is fully loaded into sessionStorage before the page continues loading and the SmartDocs Angular app initializes.

Fixes: #256